### PR TITLE
Accès internet : clé API optionnelle pour Crawl4AI

### DIFF
--- a/internal/jean/backend_config.go
+++ b/internal/jean/backend_config.go
@@ -65,6 +65,29 @@ func maskAPIKey(k string) string {
 	return k[:8] + "…" + k[len(k)-4:]
 }
 
+// readCrawlKey returns the trimmed contents of $JEAN_HOME/.crawl4ai_key, or ""
+// if unset. This is the API token sent to the Crawl4AI server, independent of
+// CRAWL4AI_URL (config.env) so it survives preset switches.
+func readCrawlKey() string {
+	b, err := os.ReadFile(crawlKeyPath())
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// writeCrawlKey persists (key != "") or clears (key == "") the Crawl4AI API
+// token in $JEAN_HOME/.crawl4ai_key.
+func writeCrawlKey(key string) error {
+	if key == "" {
+		if err := os.Remove(crawlKeyPath()); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		return nil
+	}
+	return os.WriteFile(crawlKeyPath(), []byte(key+"\n"), 0o600)
+}
+
 // cmdSetAPIKey sets (or clears) the API key stored in $JEAN_HOME/.api_key. When
 // exposed on the internet, llama-server requires "Authorization: Bearer <clé>"
 // for every call.

--- a/internal/jean/chat_internet.go
+++ b/internal/jean/chat_internet.go
@@ -20,8 +20,11 @@ import (
 // Accès internet de l'IA — port Go de l'extension pi ~/.pi/agent/extensions/web.ts.
 //
 // jean parle à un serveur Crawl4AI (Chrome headless, endpoint /crawl) dont l'URL
-// est configurée dans config.env (CRAWL4AI_URL). Quand le mode agent ET l'accès
-// internet sont actifs ET que le serveur répond, l'IA dispose de 4 outils :
+// est configurée dans config.env (CRAWL4AI_URL). Si une clé API est enregistrée
+// ($JEAN_HOME/.crawl4ai_key), elle est envoyée en "Authorization: Bearer <clé>"
+// sur chaque appel (utile quand le serveur Crawl4AI est protégé, p. ex. exposé
+// publiquement). Quand le mode agent ET l'accès internet sont actifs ET que le
+// serveur répond, l'IA dispose de 4 outils :
 //
 //   - web_search : recherche DuckDuckGo (via crawl), liste {title, url, snippet}.
 //   - web_open   : récupère une URL (cache 10 min), renvoie SEULEMENT les métadonnées
@@ -95,6 +98,9 @@ func crawlReachable() bool {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+path, nil)
 		if err != nil {
 			continue
+		}
+		if k := readCrawlKey(); k != "" {
+			req.Header.Set("Authorization", "Bearer "+k)
 		}
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -193,6 +199,9 @@ func runCrwl(target string, opts crwlOptions) (string, error) {
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if k := readCrawlKey(); k != "" {
+		req.Header.Set("Authorization", "Bearer "+k)
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("Crawl4AI injoignable (%s): %v", base, err)

--- a/internal/jean/run.go
+++ b/internal/jean/run.go
@@ -220,6 +220,7 @@ func mcpConfigPath() string { return filepath.Join(JeanHome(), "mcp.json") }
 func legacySkillsFlag() string { return filepath.Join(skillsDir(), ".enabled") }
 func legacyToolsFlag() string  { return filepath.Join(JeanHome(), ".tools_enabled") }
 func apiKeyPath() string       { return filepath.Join(JeanHome(), ".api_key") }
+func crawlKeyPath() string     { return filepath.Join(JeanHome(), ".crawl4ai_key") }
 func serviceName() string {
 	if n := os.Getenv("JEAN_SERVICE"); n != "" {
 		return n

--- a/internal/jean/ui/index.html
+++ b/internal/jean/ui/index.html
@@ -428,6 +428,12 @@ button:disabled{opacity:.5;cursor:not-allowed}
         <button onclick="saveCrawlUrl()">enregistrer</button>
       </div>
       <div id="internet-status" class="muted" style="font-size:11px;margin-top:4px"></div>
+      <div class="row" style="margin-top:6px">
+        <input id="crawl-key" readonly placeholder="(aucune clé)" style="flex:1;min-width:0;background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px;font:inherit;font-size:12px">
+        <button onclick="crawlKeySet()">définir…</button>
+        <button onclick="crawlKeyClear()">retirer</button>
+        <span class="help" tabindex="0" onclick="event.preventDefault();event.stopPropagation();this.classList.toggle('open')">?<span class="tip">Clé API envoyée en <code>Authorization: Bearer …</code> à chaque appel au serveur Crawl4AI, si celui-ci est protégé (utile quand il est exposé publiquement). Laisse vide si ton serveur Crawl4AI n'exige pas de clé.</span></span>
+      </div>
     </div>
     <div id="mcp-block" class="gated-block">
       <div class="subhead">Serveurs MCP<span id="mcp-badge" style="margin-left:6px;font-size:10px"></span><span class="help" tabindex="0" onclick="event.preventDefault();event.stopPropagation();this.classList.toggle('open')">?<span class="tip">Connecte des <b>serveurs MCP</b> (Model Context Protocol) pour donner de nouveaux outils à l'IA : accès fichiers, bases de données, APIs métier… <b>stdio</b> = programme lancé localement (npx/uvx/binaire) · <b>http</b> = serveur distant. ⚠️ un serveur stdio exécute du code sur cette machine, au même titre que le shell.</span></span></div>
@@ -1135,8 +1141,21 @@ function renderInternet(s){
   if(!s.url){ st.textContent='serveur non configuré'; st.style.color=''; }
   else if(s.reachable){ st.innerHTML='<span style="color:var(--accent)">✓</span> serveur joignable — outils web actifs'; }
   else { st.innerHTML='⚠️ serveur injoignable — les outils web ne seront pas proposés'; }
+  const ki=document.getElementById('crawl-key');
+  ki.value = s.keySet ? s.keyMasked : '';
+  ki.placeholder = s.keySet ? '' : '(aucune clé)';
 }
 async function loadInternet(){ renderInternet(await jget('/api/internet')); }
+async function crawlKeySet(){
+  const k = await askPrompt('Colle la clé API du serveur Crawl4AI (ou laisse vide pour annuler) :', {title:'Clé API Crawl4AI', placeholder:'clé…'});
+  if(!k || !k.trim()) return;
+  toast('application…');
+  renderInternet(await jpost('/api/internet',{apikey:k.trim()}));
+}
+async function crawlKeyClear(){
+  toast('application…');
+  renderInternet(await jpost('/api/internet',{apikey:''}));
+}
 // --- Accès OpenAI (endpoint /v1 + clé API des complétions) -----------------
 let OAI_KEY='', OAI_REVEAL=false;
 async function copyText(txt, msg){

--- a/internal/jean/ui/src/index.tmpl.html
+++ b/internal/jean/ui/src/index.tmpl.html
@@ -68,6 +68,12 @@
         <button onclick="saveCrawlUrl()">enregistrer</button>
       </div>
       <div id="internet-status" class="muted" style="font-size:11px;margin-top:4px"></div>
+      <div class="row" style="margin-top:6px">
+        <input id="crawl-key" readonly placeholder="(aucune clé)" style="flex:1;min-width:0;background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:6px;font:inherit;font-size:12px">
+        <button onclick="crawlKeySet()">définir…</button>
+        <button onclick="crawlKeyClear()">retirer</button>
+        <span class="help" tabindex="0" onclick="event.preventDefault();event.stopPropagation();this.classList.toggle('open')">?<span class="tip">Clé API envoyée en <code>Authorization: Bearer …</code> à chaque appel au serveur Crawl4AI, si celui-ci est protégé (utile quand il est exposé publiquement). Laisse vide si ton serveur Crawl4AI n'exige pas de clé.</span></span>
+      </div>
     </div>
     <div id="mcp-block" class="gated-block">
       <div class="subhead">Serveurs MCP<span id="mcp-badge" style="margin-left:6px;font-size:10px"></span><span class="help" tabindex="0" onclick="event.preventDefault();event.stopPropagation();this.classList.toggle('open')">?<span class="tip">Connecte des <b>serveurs MCP</b> (Model Context Protocol) pour donner de nouveaux outils à l'IA : accès fichiers, bases de données, APIs métier… <b>stdio</b> = programme lancé localement (npx/uvx/binaire) · <b>http</b> = serveur distant. ⚠️ un serveur stdio exécute du code sur cette machine, au même titre que le shell.</span></span></div>

--- a/internal/jean/ui/src/js/06-settings.js
+++ b/internal/jean/ui/src/js/06-settings.js
@@ -151,8 +151,21 @@ function renderInternet(s){
   if(!s.url){ st.textContent='serveur non configuré'; st.style.color=''; }
   else if(s.reachable){ st.innerHTML='<span style="color:var(--accent)">✓</span> serveur joignable — outils web actifs'; }
   else { st.innerHTML='⚠️ serveur injoignable — les outils web ne seront pas proposés'; }
+  const ki=document.getElementById('crawl-key');
+  ki.value = s.keySet ? s.keyMasked : '';
+  ki.placeholder = s.keySet ? '' : '(aucune clé)';
 }
 async function loadInternet(){ renderInternet(await jget('/api/internet')); }
+async function crawlKeySet(){
+  const k = await askPrompt('Colle la clé API du serveur Crawl4AI (ou laisse vide pour annuler) :', {title:'Clé API Crawl4AI', placeholder:'clé…'});
+  if(!k || !k.trim()) return;
+  toast('application…');
+  renderInternet(await jpost('/api/internet',{apikey:k.trim()}));
+}
+async function crawlKeyClear(){
+  toast('application…');
+  renderInternet(await jpost('/api/internet',{apikey:''}));
+}
 // --- Accès OpenAI (endpoint /v1 + clé API des complétions) -----------------
 let OAI_KEY='', OAI_REVEAL=false;
 async function copyText(txt, msg){

--- a/internal/jean/web_api.go
+++ b/internal/jean/web_api.go
@@ -357,8 +357,9 @@ func handleAgentToggle(w http.ResponseWriter, r *http.Request) {
 
 // handleInternet pilote l'accès web de l'IA (serveur Crawl4AI).
 //
-//	GET  → {enabled, url, reachable}
-//	POST {enabled, url} → enregistre CRAWL4AI_URL + le drapeau .internet_enabled
+//	GET  → {enabled, url, reachable, keySet, keyMasked}
+//	POST {enabled, url, apikey} → enregistre CRAWL4AI_URL, la clé API
+//	(JEAN_HOME/.crawl4ai_key) + le drapeau .internet_enabled
 //
 // handleAPIKey expose et pilote la clé d'accès à l'endpoint compatible OpenAI
 // (llama-server /v1). GET renvoie l'état ; POST {action:"generate"|"set"|"clear",
@@ -456,6 +457,7 @@ func handleInternet(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Enabled *bool   `json:"enabled"`
 			URL     *string `json:"url"`
+			APIKey  *string `json:"apikey"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req.URL != nil {
@@ -468,6 +470,15 @@ func handleInternet(w http.ResponseWriter, r *http.Request) {
 			reachURL = "" // invalide le cache de reachability
 			reachMu.Unlock()
 		}
+		if req.APIKey != nil {
+			if err := writeCrawlKey(strings.TrimSpace(*req.APIKey)); err != nil {
+				sendJSON(w, 500, map[string]any{"ok": false, "error": err.Error()})
+				return
+			}
+			reachMu.Lock()
+			reachURL = "" // la clé change l'accessibilité du serveur
+			reachMu.Unlock()
+		}
 		if req.Enabled != nil {
 			if err := setInternetEnabled(*req.Enabled); err != nil {
 				sendJSON(w, 500, map[string]any{"ok": false, "error": err.Error()})
@@ -475,11 +486,14 @@ func handleInternet(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	k := readCrawlKey()
 	sendJSON(w, 200, map[string]any{
 		"ok":        true,
 		"enabled":   internetEnabled(),
 		"url":       crawl4aiURL(),
 		"reachable": crawlReachable(),
+		"keySet":    k != "",
+		"keyMasked": maskAPIKey(k),
 	})
 }
 


### PR DESCRIPTION
## Pourquoi

Le serveur Crawl4AI officiel (image Docker `unclecode/crawl4ai`) supporte
une authentification par jeton : dès que la variable d'environnement
`CRAWL4AI_API_TOKEN` est définie au lancement du conteneur, chaque appel à
l'API doit porter l'en-tête `Authorization: Bearer <jeton>`, sinon le
serveur répond 401/403.

C'est le cas de figure recommandé — et souvent la config par défaut des
guides de déploiement — dès que le conteneur Crawl4AI n'écoute pas
strictement sur `127.0.0.1` (déploiement sur un réseau Docker partagé, un
serveur distant, un NAS, etc.) : sans jeton, `/crawl` est un point
d'entrée ouvert qui exécute du Chrome headless et peut requêter n'importe
quelle URL pour n'importe qui capable d'atteindre le port. Beaucoup
d'utilisateurs activent donc `CRAWL4AI_API_TOKEN` par précaution même en
LAN.

Avant ce patch, jean n'avait aucun moyen d'envoyer ce jeton : dès que le
serveur Crawl4AI exigeait une authentification, les outils web
(`web_search` / `web_open` / `web_read` / `web_grep`) échouaient
silencieusement (serveur "injoignable" alors qu'il répondait, juste avec
un 401/403).

## Ce que fait ce patch

- Nouveau champ **clé API** dans le panneau *Accès internet* de l'UI, à
  côté de l'URL du serveur Crawl4AI.
- La clé est stockée séparément de `config.env`, dans
  `$JEAN_HOME/.crawl4ai_key` (même modèle que la clé de complétion
  OpenAI dans `.api_key`) — elle survit donc aux changements de preset.
- Envoyée en `Authorization: Bearer <clé>` sur chaque appel au serveur
  Crawl4AI : `/crawl` (recherche/lecture de pages) et le health check de
  reachability (`/health`, `/`).
- Champ **optionnel** : si aucune clé n'est renseignée, comportement
  strictement inchangé (pas d'en-tête `Authorization` envoyé) — pas de
  régression pour les déploiements Crawl4AI sans authentification.

## Test plan

- [x] `go build ./...` et `go vet ./...` passent.
- [x] `go run ./tools/assemble-ui` régénère `index.html` à l'identique du
      patch appliqué manuellement (pas de dérive template/JS ↔ bundle).
- [ ] Test manuel bout-en-bout avec un serveur Crawl4AI Docker lancé avec
      `CRAWL4AI_API_TOKEN` défini : sans clé côté jean → 401 visible
      ("serveur injoignable") ; avec la clé renseignée dans l'UI →
      `web_search`/`web_open` fonctionnels.