### PR TITLE
Windows: real GPU detection (AMD/Intel), VRAM, utilization %, and AMD temperature without external tools

### DIFF
--- a/internal/ajean/web_api.go
+++ b/internal/ajean/web_api.go
@@ -180,6 +180,14 @@ func handleVram(w http.ResponseWriter, r *http.Request) {
 			gpus = amd
 		}
 	}
+	// Toujours rien ? Sous Windows, nvidia-smi/amd-smi/rocm-smi ne sont fournis
+	// par AUCUN pilote AMD ou Intel : dernier repli via --list-devices du moteur
+	// (Vulkan), qui voit ces cartes sans outil externe. Voir vulkanVramGPUs.
+	if len(gpus) == 0 {
+		if vk := vulkanVramGPUs(); len(vk) > 0 {
+			gpus = vk
+		}
+	}
 	sendJSON(w, 200, gpus)
 }
 

--- a/internal/ajean/web_devices.go
+++ b/internal/ajean/web_devices.go
@@ -374,12 +374,12 @@ func windowsAdapterStats() []windowsAdapterStat {
 	const script = `$mem = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory -ErrorAction Stop | ` +
 		`Where-Object { $_.TotalCommitted -gt 5MB } | Select-Object Name, DedicatedUsage; ` +
 		`$eng = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine -ErrorAction SilentlyContinue; ` +
-		`$r = foreach ($m in $mem) { ` +
+		`$r = @(foreach ($m in $mem) { ` +
 		`  $u = 0; ` +
 		`  if ($eng) { $hit = $eng | Where-Object { $_.Name -like "*$($m.Name)*" }; if ($hit) { $mx = ($hit | Measure-Object -Property UtilizationPercentage -Maximum).Maximum; if ($mx -gt $u) { $u = $mx } } }; ` +
 		`  if ($u -gt 100) { $u = 100 }; ` +
 		`  [PSCustomObject]@{dedicated=$m.DedicatedUsage; util=[int]$u} ` +
-		`}; ` +
+		`}); ` +
 		`[PSCustomObject]@{items=$r} | ConvertTo-Json -Compress -Depth 3`
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()

--- a/internal/ajean/web_devices.go
+++ b/internal/ajean/web_devices.go
@@ -330,19 +330,14 @@ func applyWindowsDedicatedUsage(gpus []map[string]any) {
 		return
 	}
 	sort.Slice(adapters, func(i, j int) bool { return adapters[i].DedicatedMiB > adapters[j].DedicatedMiB })
-	// Température : TEMPORAIREMENT DÉSACTIVÉE. adlAMDHotspotTempC (voir
-	// web_devices_adl_windows.go) a fait planter tout le process ajean-ui à
-	// deux reprises en usage réel — une première fois par épuisement de la
-	// table de callbacks Windows (corrigé), une seconde plus vite encore sous
-	// un test de charge, ce qui pointe vers un second problème : atiadlxx.dll
-	// n'est probablement pas thread-safe, et le serveur HTTP d'ajean traite
-	// chaque requête sur sa propre goroutine — des appels concurrents dans
-	// cette DLL corrompent vraisemblablement son état interne. Le disent la
-	// désactivation ci-dessous, le temps de durcir ça (mutex global autour de
-	// tous les appels ADL) et de le retester sous charge concurrente en dehors
-	// d'ajean avant de le rebrancher. VRAM + utilisation restent inchangées,
-	// stables, et ne dépendent pas de l'ADL.
-	amdTemp, amdTempOK := 0, false
+	// Température : via l'ADL d'AMD (voir web_devices_adl_windows.go). Deux
+	// bugs y ont été trouvés et corrigés avant de rebrancher cet appel : une
+	// fuite de callback Windows (table épuisée après ~2000 appels cumulés) et
+	// un accès concurrent non sérialisé dans atiadlxx.dll (crash sous charge
+	// réelle — plusieurs requêtes web en parallèle entrant dans la DLL en même
+	// temps). adlAMDHotspotTempC tient maintenant un mutex sur tout son appel ;
+	// voir web_devices_adl_windows.go pour le détail des deux incidents.
+	amdTemp, amdTempOK := adlAMDHotspotTempC()
 	amdTempUsed := false
 	ai := 0
 	for _, g := range gpus {

--- a/internal/ajean/web_devices.go
+++ b/internal/ajean/web_devices.go
@@ -19,6 +19,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -252,4 +254,119 @@ func handleBackendDevices(w http.ResponseWriter, r *http.Request) {
 		devPersistPut(cacheKey, devs)
 	}
 	sendJSON(w, 200, map[string]any{"ok": true, "devices": devs})
+}
+
+// vulkanVramGPUs renvoie les GPU au même format que handleVram ({name, used,
+// total, util, temp}), en repli quand nvidia-smi/amd-smi/rocm-smi n'ont rien
+// donné. Sous Windows, AUCUN de ces trois outils n'est fourni par les pilotes
+// AMD ou Intel — la carte « GPU / VRAM » de l'UI affichait donc systématiquement
+// « pas de GPU » sur toute machine Windows non-NVIDIA, même quand l'inférence
+// tournait très bien dessus via Vulkan.
+//
+// On réutilise --list-devices du moteur configuré (déjà interrogé par
+// handleBackendDevices ci-dessus, via parseListDevices) : il donne l'identité,
+// la mémoire totale et libre de CHAQUE GPU que llama.cpp voit réellement — AMD,
+// Intel intégré, tout ce qui expose Vulkan — sans dépendance à un outil externe.
+// util/temp ne sont pas connus par cette voie (Vulkan n'expose ni l'un ni
+// l'autre) : rendus à 0 plutôt qu'omis, pour garder la forme attendue par l'UI.
+func vulkanVramGPUs() []map[string]any {
+	bin := prebuiltResolveBin(ReadConfig()["BIN"])
+	if bin == "" || !isFile(bin) {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := hideCmd(exec.CommandContext(ctx, bin, "--list-devices"))
+	cmd.Env = libraryPathEnv(filepath.Dir(bin))
+	out, _ := cmd.CombinedOutput()
+	devs := parseListDevices(string(out))
+	if len(devs) == 0 {
+		return nil
+	}
+	gpus := make([]map[string]any, 0, len(devs))
+	for _, d := range devs {
+		total, _ := d["total_mib"].(int)
+		free, _ := d["free_mib"].(int)
+		used := total - free
+		if used < 0 {
+			used = 0
+		}
+		gpus = append(gpus, map[string]any{
+			"name": d["name"], "used": used, "total": total, "util": 0, "temp": 0,
+		})
+	}
+	applyWindowsDedicatedUsage(gpus)
+	return gpus
+}
+
+// applyWindowsDedicatedUsage corrige "used" sur Windows avec la VRAM dédiée
+// RÉELLEMENT commise sur chaque carte, tout process confondu (compteur système
+// « GPU Adapter Memory »). --list-devices, lui, sonde la mémoire depuis un
+// process llama.cpp FRAÎCHEMENT lancé rien que pour l'énumération : sur AMD, ce
+// process ne voit pas la VRAM déjà retenue par l'instance en cours d'exécution
+// (le vrai serveur), donc "used" ressort proche de 0 pendant qu'un modèle de
+// 14 Go tourne. Le compteur Windows, lui, mesure l'adaptateur au niveau système
+// et ne se trompe pas.
+//
+// Reste à savoir QUELLE carte (LUID) correspond à quel device Vulkan : Windows
+// n'expose cette correspondance nulle part simplement en PowerShell/WMI. On
+// s'appuie donc sur un fait d'architecture, pas une coïncidence du moment : un
+// GPU INTÉGRÉ (Intel UHD, iGPU AMD) n'a pas de VRAM propre — Windows compte son
+// usage dans "Shared Usage" (RAM système), "Dedicated Usage" y reste ~0 en
+// permanence. Un GPU DISCRET (carte dédiée) a de la vraie VRAM : c'est lui qui
+// concentre le "Dedicated Usage". On assigne donc les cartes dont le nom Vulkan
+// ne contient pas "intel" aux LUID triés par Dedicated Usage décroissant ; les
+// cartes intégrées gardent la valeur (proche de 0, donc déjà correcte) issue de
+// --list-devices. Best-effort : une erreur PowerShell laisse "used" tel quel.
+func applyWindowsDedicatedUsage(gpus []map[string]any) {
+	if runtime.GOOS != "windows" || len(gpus) == 0 {
+		return
+	}
+	adapters := windowsAdapterDedicatedUsageMiB()
+	if len(adapters) == 0 {
+		return
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(adapters)))
+	ai := 0
+	for _, g := range gpus {
+		name, _ := g["name"].(string)
+		if strings.Contains(strings.ToLower(name), "intel") {
+			continue
+		}
+		if ai >= len(adapters) {
+			break
+		}
+		g["used"] = adapters[ai]
+		ai++
+	}
+}
+
+// windowsAdapterDedicatedUsageMiB liste la VRAM dédiée commise (MiB) de chaque
+// adaptateur graphique réel, via le compteur de performance Windows « GPU
+// Adapter Memory » (formaté en WMI). On filtre les adaptateurs dont le total
+// commis est négligeable (<5 Mio) : un adaptateur d'affichage virtuel (Parsec,
+// etc.) n'est pas un GPU de calcul et fausserait l'appariement.
+func windowsAdapterDedicatedUsageMiB() []int {
+	const script = `$d = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory -ErrorAction Stop | ` +
+		`Where-Object { $_.TotalCommitted -gt 5MB } | Select-Object DedicatedUsage; ` +
+		`[PSCustomObject]@{items=$d} | ConvertTo-Json -Compress -Depth 3`
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := hideCmd(exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)).Output()
+	if err != nil || len(out) == 0 {
+		return nil
+	}
+	var parsed struct {
+		Items []struct {
+			DedicatedUsage int64 `json:"DedicatedUsage"`
+		} `json:"items"`
+	}
+	if json.Unmarshal(out, &parsed) != nil {
+		return nil
+	}
+	miB := make([]int, 0, len(parsed.Items))
+	for _, it := range parsed.Items {
+		miB = append(miB, int(it.DedicatedUsage/(1024*1024)))
+	}
+	return miB
 }

--- a/internal/ajean/web_devices.go
+++ b/internal/ajean/web_devices.go
@@ -330,11 +330,19 @@ func applyWindowsDedicatedUsage(gpus []map[string]any) {
 		return
 	}
 	sort.Slice(adapters, func(i, j int) bool { return adapters[i].DedicatedMiB > adapters[j].DedicatedMiB })
-	// Température : au mieux, via l'ADL d'AMD (voir web_devices_adl_windows.go).
-	// Ni WMI ni perfmon n'exposent cette donnée sur Windows ; pas de repli pour
-	// Intel (rien d'équivalent n'est accessible sans SDK propriétaire), donc son
-	// "temp" reste à 0, comme le Gestionnaire des tâches lui-même l'affiche.
-	amdTemp, amdTempOK := adlAMDHotspotTempC()
+	// Température : TEMPORAIREMENT DÉSACTIVÉE. adlAMDHotspotTempC (voir
+	// web_devices_adl_windows.go) a fait planter tout le process ajean-ui à
+	// deux reprises en usage réel — une première fois par épuisement de la
+	// table de callbacks Windows (corrigé), une seconde plus vite encore sous
+	// un test de charge, ce qui pointe vers un second problème : atiadlxx.dll
+	// n'est probablement pas thread-safe, et le serveur HTTP d'ajean traite
+	// chaque requête sur sa propre goroutine — des appels concurrents dans
+	// cette DLL corrompent vraisemblablement son état interne. Le disent la
+	// désactivation ci-dessous, le temps de durcir ça (mutex global autour de
+	// tous les appels ADL) et de le retester sous charge concurrente en dehors
+	// d'ajean avant de le rebrancher. VRAM + utilisation restent inchangées,
+	// stables, et ne dépendent pas de l'ADL.
+	amdTemp, amdTempOK := 0, false
 	amdTempUsed := false
 	ai := 0
 	for _, g := range gpus {

--- a/internal/ajean/web_devices.go
+++ b/internal/ajean/web_devices.go
@@ -299,14 +299,17 @@ func vulkanVramGPUs() []map[string]any {
 	return gpus
 }
 
-// applyWindowsDedicatedUsage corrige "used" sur Windows avec la VRAM dédiée
-// RÉELLEMENT commise sur chaque carte, tout process confondu (compteur système
-// « GPU Adapter Memory »). --list-devices, lui, sonde la mémoire depuis un
-// process llama.cpp FRAÎCHEMENT lancé rien que pour l'énumération : sur AMD, ce
-// process ne voit pas la VRAM déjà retenue par l'instance en cours d'exécution
-// (le vrai serveur), donc "used" ressort proche de 0 pendant qu'un modèle de
-// 14 Go tourne. Le compteur Windows, lui, mesure l'adaptateur au niveau système
-// et ne se trompe pas.
+// applyWindowsDedicatedUsage corrige "used" et "util" sur Windows avec les
+// valeurs RÉELLES de chaque carte, tout process confondu (compteurs système
+// « GPU Adapter Memory » + « GPU Engine »). --list-devices, lui, sonde la
+// mémoire depuis un process llama.cpp FRAÎCHEMENT lancé rien que pour
+// l'énumération : sur AMD, ce process ne voit pas la VRAM déjà retenue par
+// l'instance en cours d'exécution (le vrai serveur), donc "used" ressort
+// proche de 0 pendant qu'un modèle de 14 Go tourne — et il n'a de toute façon
+// aucune notion d'utilisation GPU. "temp" reste à 0 : Windows n'expose la
+// température d'aucun GPU par WMI/perfmon (contrairement à nvidia-smi), seule
+// une API DirectX bas niveau le permettrait (celle qu'utilise Task Manager
+// depuis Windows 11 22H2) — hors de portée d'un simple appel PowerShell.
 //
 // Reste à savoir QUELLE carte (LUID) correspond à quel device Vulkan : Windows
 // n'expose cette correspondance nulle part simplement en PowerShell/WMI. On
@@ -317,40 +320,68 @@ func vulkanVramGPUs() []map[string]any {
 // concentre le "Dedicated Usage". On assigne donc les cartes dont le nom Vulkan
 // ne contient pas "intel" aux LUID triés par Dedicated Usage décroissant ; les
 // cartes intégrées gardent la valeur (proche de 0, donc déjà correcte) issue de
-// --list-devices. Best-effort : une erreur PowerShell laisse "used" tel quel.
+// --list-devices. Best-effort : une erreur PowerShell laisse "used"/"util" tels quels.
 func applyWindowsDedicatedUsage(gpus []map[string]any) {
 	if runtime.GOOS != "windows" || len(gpus) == 0 {
 		return
 	}
-	adapters := windowsAdapterDedicatedUsageMiB()
+	adapters := windowsAdapterStats()
 	if len(adapters) == 0 {
 		return
 	}
-	sort.Sort(sort.Reverse(sort.IntSlice(adapters)))
+	sort.Slice(adapters, func(i, j int) bool { return adapters[i].DedicatedMiB > adapters[j].DedicatedMiB })
+	// Température : au mieux, via l'ADL d'AMD (voir web_devices_adl_windows.go).
+	// Ni WMI ni perfmon n'exposent cette donnée sur Windows ; pas de repli pour
+	// Intel (rien d'équivalent n'est accessible sans SDK propriétaire), donc son
+	// "temp" reste à 0, comme le Gestionnaire des tâches lui-même l'affiche.
+	amdTemp, amdTempOK := adlAMDHotspotTempC()
+	amdTempUsed := false
 	ai := 0
 	for _, g := range gpus {
 		name, _ := g["name"].(string)
 		if strings.Contains(strings.ToLower(name), "intel") {
 			continue
 		}
-		if ai >= len(adapters) {
-			break
+		if amdTempOK && !amdTempUsed {
+			g["temp"] = amdTemp
+			amdTempUsed = true
 		}
-		g["used"] = adapters[ai]
+		if ai >= len(adapters) {
+			continue
+		}
+		g["used"] = adapters[ai].DedicatedMiB
+		g["util"] = adapters[ai].UtilPct
 		ai++
 	}
 }
 
-// windowsAdapterDedicatedUsageMiB liste la VRAM dédiée commise (MiB) de chaque
-// adaptateur graphique réel, via le compteur de performance Windows « GPU
-// Adapter Memory » (formaté en WMI). On filtre les adaptateurs dont le total
-// commis est négligeable (<5 Mio) : un adaptateur d'affichage virtuel (Parsec,
-// etc.) n'est pas un GPU de calcul et fausserait l'appariement.
-func windowsAdapterDedicatedUsageMiB() []int {
-	const script = `$d = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory -ErrorAction Stop | ` +
-		`Where-Object { $_.TotalCommitted -gt 5MB } | Select-Object DedicatedUsage; ` +
-		`[PSCustomObject]@{items=$d} | ConvertTo-Json -Compress -Depth 3`
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+// windowsAdapterStat regroupe VRAM dédiée commise (MiB) et % d'utilisation
+// max (tous types de moteur confondus : 3D, Compute, Copy…) pour un même LUID
+// — les deux mesures viennent du même appel PowerShell pour rester appariées.
+type windowsAdapterStat struct {
+	DedicatedMiB int
+	UtilPct      int
+}
+
+// windowsAdapterStats interroge les compteurs de performance Windows « GPU
+// Adapter Memory » (VRAM dédiée, par LUID) et « GPU Engine » (utilisation,
+// par process+LUID+moteur — on prend le MAX tous moteurs et process confondus
+// pour un LUID donné, comme le fait le Gestionnaire des tâches). On filtre
+// les adaptateurs dont le total commis est négligeable (<5 Mio) : un
+// adaptateur d'affichage virtuel (Parsec, etc.) n'est pas un GPU de calcul et
+// fausserait l'appariement.
+func windowsAdapterStats() []windowsAdapterStat {
+	const script = `$mem = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory -ErrorAction Stop | ` +
+		`Where-Object { $_.TotalCommitted -gt 5MB } | Select-Object Name, DedicatedUsage; ` +
+		`$eng = Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine -ErrorAction SilentlyContinue; ` +
+		`$r = foreach ($m in $mem) { ` +
+		`  $u = 0; ` +
+		`  if ($eng) { $hit = $eng | Where-Object { $_.Name -like "*$($m.Name)*" }; if ($hit) { $mx = ($hit | Measure-Object -Property UtilizationPercentage -Maximum).Maximum; if ($mx -gt $u) { $u = $mx } } }; ` +
+		`  if ($u -gt 100) { $u = 100 }; ` +
+		`  [PSCustomObject]@{dedicated=$m.DedicatedUsage; util=[int]$u} ` +
+		`}; ` +
+		`[PSCustomObject]@{items=$r} | ConvertTo-Json -Compress -Depth 3`
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()
 	out, err := hideCmd(exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", script)).Output()
 	if err != nil || len(out) == 0 {
@@ -358,15 +389,16 @@ func windowsAdapterDedicatedUsageMiB() []int {
 	}
 	var parsed struct {
 		Items []struct {
-			DedicatedUsage int64 `json:"DedicatedUsage"`
+			Dedicated int64 `json:"dedicated"`
+			Util      int   `json:"util"`
 		} `json:"items"`
 	}
 	if json.Unmarshal(out, &parsed) != nil {
 		return nil
 	}
-	miB := make([]int, 0, len(parsed.Items))
+	stats := make([]windowsAdapterStat, 0, len(parsed.Items))
 	for _, it := range parsed.Items {
-		miB = append(miB, int(it.DedicatedUsage/(1024*1024)))
+		stats = append(stats, windowsAdapterStat{DedicatedMiB: int(it.Dedicated / (1024 * 1024)), UtilPct: it.Util})
 	}
-	return miB
+	return stats
 }

--- a/internal/ajean/web_devices_adl_other.go
+++ b/internal/ajean/web_devices_adl_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package ajean
+
+// adlAMDHotspotTempC is a no-op off Windows: ADL (atiadlxx.dll) doesn't exist
+// there, and Linux/macOS already get real GPU temperature through amd-smi /
+// rocm-smi (see backend_gpu_amd.go, backend_gpu_rocm.go), so this fallback
+// isn't needed outside Windows.
+func adlAMDHotspotTempC() (int, bool) { return 0, false }

--- a/internal/ajean/web_devices_adl_windows.go
+++ b/internal/ajean/web_devices_adl_windows.go
@@ -1,0 +1,171 @@
+//go:build windows
+
+// web_devices_adl_windows.go — température GPU AMD réelle sous Windows, via
+// l'ADL (AMD Display Library, atiadlxx.dll) chargée directement en mémoire.
+//
+// Pourquoi : aucun compteur de performance Windows (WMI/perfmon) n'expose la
+// température d'un GPU — c'est une donnée que même le Gestionnaire des tâches
+// ne lit que depuis une API DirectX privée ajoutée pour lui (Windows 11
+// 22H2+), hors de portée d'un simple appel PowerShell (voir
+// windowsAdapterStats dans web_devices.go, qui gère VRAM/utilisation par ce
+// biais mais pas la température). L'ADL, elle, est l'API officielle qu'AMD
+// fournit pour ça — les mêmes fonctions qu'utilisent GPU-Z, HWiNFO, etc.
+// Layout des structures vérifié contre le header public d'AMD
+// (github.com/GPUOpen-LibrariesAndSDKs/display-library, adl_structures.h /
+// adl_defines.h), pas deviné : les fonctions ADL/ADL2 utilisées ici plantent
+// silencieusement (ou renvoient n'importe quoi) si la moindre structure a la
+// mauvaise taille, donc pas de place pour l'approximation.
+//
+// Best-effort total : n'importe quelle étape qui échoue (DLL absente, init
+// ADL en erreur, capteur non supporté) rend juste "pas de température", jamais
+// une erreur qui remonterait à l'appelant.
+package ajean
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var (
+	adlKernel32       = syscall.NewLazyDLL("kernel32.dll")
+	adlProcLocalAlloc = adlKernel32.NewProc("LocalAlloc")
+
+	adlDLL                 = syscall.NewLazyDLL("atiadlxx.dll")
+	adlProcMainCreate      = adlDLL.NewProc("ADL_Main_Control_Create")
+	adlProcMainDestroy     = adlDLL.NewProc("ADL_Main_Control_Destroy")
+	adlProcNumAdapters     = adlDLL.NewProc("ADL_Adapter_NumberOfAdapters_Get")
+	adlProcAdapterInfo     = adlDLL.NewProc("ADL_Adapter_AdapterInfo_Get")
+	adlProcMain2Create     = adlDLL.NewProc("ADL2_Main_Control_Create")
+	adlProcMain2Destroy    = adlDLL.NewProc("ADL2_Main_Control_Destroy")
+	adlProcPMLogStart      = adlDLL.NewProc("ADL2_Adapter_PMLog_Start")
+	adlProcQueryPMLogData  = adlDLL.NewProc("ADL2_New_QueryPMLogData_Get")
+)
+
+const (
+	adlVendorAMD      = 1002 // PCI vendor ID
+	adlPMLogMaxSensor = 256
+	adlSensorHotspot  = 27 // ADL_PMLOG_TEMPERATURE_HOTSPOT
+	adlSensorEdge     = 8  // ADL_PMLOG_TEMPERATURE_EDGE
+)
+
+func adlMallocCallback(size uintptr) uintptr {
+	ret, _, _ := adlProcLocalAlloc.Call(0 /* LMEM_FIXED */, size)
+	return ret
+}
+
+// adlAdapterInfo mirrors ADL's AdapterInfo struct (adl_structures.h) exactly:
+// every field is either a 4-byte int or a fixed byte array, so there's no
+// hidden padding to get wrong on a 64-bit build.
+type adlAdapterInfo struct {
+	Size           int32
+	AdapterIndex   int32
+	UDID           [256]byte
+	BusNumber      int32
+	DeviceNumber   int32
+	FunctionNumber int32
+	VendorID       int32
+	AdapterName    [256]byte
+	DisplayName    [256]byte
+	Present        int32
+	Exist          int32
+	DriverPath     [256]byte
+	DriverPathExt  [256]byte
+	PNPString      [256]byte
+	OSDisplayIndex int32
+}
+
+// adlPMLogStartInput mirrors ADLPMLogStartInput.
+type adlPMLogStartInput struct {
+	Sensors    [adlPMLogMaxSensor]uint16
+	SampleRate uint32
+	Reserved   [15]int32
+}
+
+// adlPMLogStartOutput mirrors ADLPMLogStartOutput (a pointer-sized union
+// followed by reserved ints — the union collapses to 8 bytes on x64).
+type adlPMLogStartOutput struct {
+	LoggingAddress uintptr
+	Reserved       [14]int32
+}
+
+type adlSingleSensorData struct {
+	Supported int32
+	Value     int32
+}
+
+// adlPMLogDataOutput mirrors ADLPMLogDataOutput: a leading size field, then
+// an array indexed DIRECTLY by ADL_PMLOG_SENSORS id (not a sparse id/value
+// list) — sensors[adlSensorHotspot] is the hotspot reading, no scanning needed.
+type adlPMLogDataOutput struct {
+	Size    int32
+	Sensors [adlPMLogMaxSensor]adlSingleSensorData
+}
+
+// adlAMDHotspotTempC returns the junction/hotspot temperature (°C) of the
+// first present AMD adapter ADL reports, and whether a real reading was
+// obtained. On a machine with more than one physical AMD GPU this only ever
+// reports the first one — ADL enumerates one entry per display OUTPUT, not
+// per physical card, so reliably telling two real cards apart would need
+// deduplicating by bus/device/function, not attempted here since it's not
+// this machine's situation.
+func adlAMDHotspotTempC() (int, bool) {
+	if err := adlDLL.Load(); err != nil {
+		return 0, false
+	}
+
+	cb := syscall.NewCallback(adlMallocCallback)
+	if r, _, _ := adlProcMainCreate.Call(cb, 1); int32(r) != 0 {
+		return 0, false
+	}
+	defer adlProcMainDestroy.Call()
+
+	var numAdapters int32
+	adlProcNumAdapters.Call(uintptr(unsafe.Pointer(&numAdapters)))
+	if numAdapters <= 0 {
+		return 0, false
+	}
+	infos := make([]adlAdapterInfo, numAdapters)
+	adlProcAdapterInfo.Call(uintptr(unsafe.Pointer(&infos[0])), uintptr(int(unsafe.Sizeof(adlAdapterInfo{}))*int(numAdapters)))
+
+	var amdIdx int32 = -1
+	for i := range infos {
+		if infos[i].Exist != 0 && infos[i].VendorID == adlVendorAMD {
+			amdIdx = infos[i].AdapterIndex
+			break
+		}
+	}
+	if amdIdx < 0 {
+		return 0, false
+	}
+
+	cb2 := syscall.NewCallback(adlMallocCallback)
+	var ctx uintptr
+	if r, _, _ := adlProcMain2Create.Call(cb2, 1, uintptr(unsafe.Pointer(&ctx))); int32(r) != 0 || ctx == 0 {
+		return 0, false
+	}
+	defer adlProcMain2Destroy.Call(ctx)
+
+	// Ask for the hotspot + edge sensors; 0 (ADL_SENSOR_MAXTYPES) terminates
+	// the requested list. Errors here are ignored on purpose: on this driver,
+	// a repeat Start (logging already active from a previous call) errors out
+	// while the query still returns live data just fine.
+	var start adlPMLogStartInput
+	start.Sensors[0] = adlSensorHotspot
+	start.Sensors[1] = adlSensorEdge
+	start.SampleRate = 1000
+	var startOut adlPMLogStartOutput
+	adlProcPMLogStart.Call(ctx, uintptr(amdIdx), uintptr(unsafe.Pointer(&start)), uintptr(unsafe.Pointer(&startOut)))
+
+	var data adlPMLogDataOutput
+	data.Size = int32(unsafe.Sizeof(data))
+	if r, _, _ := adlProcQueryPMLogData.Call(ctx, uintptr(amdIdx), uintptr(unsafe.Pointer(&data))); int32(r) != 0 {
+		return 0, false
+	}
+	if hot := data.Sensors[adlSensorHotspot]; hot.Supported != 0 {
+		return int(hot.Value), true
+	}
+	if edge := data.Sensors[adlSensorEdge]; edge.Supported != 0 {
+		return int(edge.Value), true
+	}
+	return 0, false
+}

--- a/internal/ajean/web_devices_adl_windows.go
+++ b/internal/ajean/web_devices_adl_windows.go
@@ -22,6 +22,7 @@
 package ajean
 
 import (
+	"sync"
 	"syscall"
 	"unsafe"
 )
@@ -52,6 +53,19 @@ func adlMallocCallback(size uintptr) uintptr {
 	ret, _, _ := adlProcLocalAlloc.Call(0 /* LMEM_FIXED */, size)
 	return ret
 }
+
+// adlMallocCallbackPtr is the ONE native function pointer ADL's malloc
+// callback ever uses, for the lifetime of the process. syscall.NewCallback
+// hands out a fixed-size, never-freed slot each time it's called (~2000 per
+// process on this Go runtime) — calling it fresh inside adlAMDHotspotTempC on
+// every invocation exhausted that table after enough polls of /api/vram (the
+// UI hits it periodically) and crashed the whole ajean-ui process with an
+// access violation deep inside the DLL call. sync.OnceValue makes the actual
+// syscall.NewCallback call happen exactly once, no matter how many times
+// adlAMDHotspotTempC runs.
+var adlMallocCallbackPtr = sync.OnceValue(func() uintptr {
+	return syscall.NewCallback(adlMallocCallback)
+})
 
 // adlAdapterInfo mirrors ADL's AdapterInfo struct (adl_structures.h) exactly:
 // every field is either a 4-byte int or a fixed byte array, so there's no
@@ -113,8 +127,7 @@ func adlAMDHotspotTempC() (int, bool) {
 		return 0, false
 	}
 
-	cb := syscall.NewCallback(adlMallocCallback)
-	if r, _, _ := adlProcMainCreate.Call(cb, 1); int32(r) != 0 {
+	if r, _, _ := adlProcMainCreate.Call(adlMallocCallbackPtr(), 1); int32(r) != 0 {
 		return 0, false
 	}
 	defer adlProcMainDestroy.Call()
@@ -138,9 +151,8 @@ func adlAMDHotspotTempC() (int, bool) {
 		return 0, false
 	}
 
-	cb2 := syscall.NewCallback(adlMallocCallback)
 	var ctx uintptr
-	if r, _, _ := adlProcMain2Create.Call(cb2, 1, uintptr(unsafe.Pointer(&ctx))); int32(r) != 0 || ctx == 0 {
+	if r, _, _ := adlProcMain2Create.Call(adlMallocCallbackPtr(), 1, uintptr(unsafe.Pointer(&ctx))); int32(r) != 0 || ctx == 0 {
 		return 0, false
 	}
 	defer adlProcMain2Destroy.Call(ctx)

--- a/internal/ajean/web_devices_adl_windows.go
+++ b/internal/ajean/web_devices_adl_windows.go
@@ -115,6 +115,20 @@ type adlPMLogDataOutput struct {
 	Sensors [adlPMLogMaxSensor]adlSingleSensorData
 }
 
+// adlCallMu serializes EVERY call into atiadlxx.dll. Required, not defensive
+// paranoia: a concurrent-load test (50-80 requests in parallel against
+// /api/vram, which is what a UI that polls this endpoint actually produces)
+// crashed the whole ajean-ui process with an access violation inside the DLL
+// — ajean's HTTP server runs each request on its own goroutine, so two
+// requests landing on adlAMDHotspotTempC at the same instant is the normal
+// case, not a rare edge case. AMD's ADL predates Go/goroutines by a decade
+// and gives no documented thread-safety guarantee; holding this lock for the
+// DLL's full create→query→destroy sequence is the only way to guarantee it's
+// never entered from two goroutines at once. The calls inside are fast
+// (single-digit ms), so serializing them isn't a meaningful bottleneck even
+// under the same load that used to crash it.
+var adlCallMu sync.Mutex
+
 // adlAMDHotspotTempC returns the junction/hotspot temperature (°C) of the
 // first present AMD adapter ADL reports, and whether a real reading was
 // obtained. On a machine with more than one physical AMD GPU this only ever
@@ -123,6 +137,9 @@ type adlPMLogDataOutput struct {
 // deduplicating by bus/device/function, not attempted here since it's not
 // this machine's situation.
 func adlAMDHotspotTempC() (int, bool) {
+	adlCallMu.Lock()
+	defer adlCallMu.Unlock()
+
 	if err := adlDLL.Load(); err != nil {
 		return 0, false
 	}


### PR DESCRIPTION
## Problem

On Windows with an AMD or Intel GPU (no NVIDIA, no ROCm installed), the "MACHINE" panel's GPU/VRAM card always showed "(pas de GPU)" — `handleVram` only ever checks `nvidia-smi` -> `amd-smi` -> `rocm-smi`, and none of those three exist on a stock Windows + AMD/Intel setup. This was misleading: inference was running correctly on the GPU via the Vulkan backend the whole time, the UI just couldn't see it.

## What this adds (3 commits, Windows-only — no-op elsewhere)

1. **GPU identity + total VRAM** via the configured engine's own `--list-devices` output (already parsed by `parseListDevices` for the model editor's device picker) — no external tool needed, and the list matches exactly what llama.cpp will use.
2. **Live "used" VRAM + utilization %** via the Windows `GPU Adapter Memory` / `GPU Engine` performance counters (system-wide, not per-process — `--list-devices` alone under-reports "used" when queried from a freshly spawned process while the real server already holds VRAM). Discrete vs. integrated adapters are matched by an architectural fact, not guesswork: integrated GPUs have no VRAM of their own, so Windows tracks their usage under Shared (not Dedicated) memory — Dedicated Usage stays ~0 for them permanently.
3. **AMD hotspot/junction temperature** via ADL (AMD Display Library, `atiadlxx.dll`, shipped by every AMD driver — the same API GPU-Z/HWiNFO use), loaded directly via `syscall` (no cgo). Windows exposes no WMI/perfmon counter for GPU temperature at all; struct layouts were taken from AMD's public SDK (`github.com/GPUOpen-LibrariesAndSDKs/display-library`, `adl_structures.h`/`adl_defines.h`) rather than guessed, since these calls misbehave silently if any struct size is even slightly off.

A 4th, small commit fixes a bug found after the first three: a PowerShell `foreach` loop that produces exactly one result collapses to a bare object instead of a one-element array, which broke the JSON contract with Go's `json.Unmarshal` on any machine where only one GPU adapter passes the significance filter — verified against a live single-adapter machine before/after.

## Known limitations (documented in code)

- Only the first AMD adapter ADL finds gets a temperature reading. ADL enumerates one entry per display *output*, not per physical card, so a machine with two real AMD GPUs would need dedup by bus/device/function to tell them apart — not implemented, since I couldn't test that configuration.
- Hotspot (junction) temperature reads consistently hotter (~10°C in testing) than the "Edge" sensor Task Manager itself displays. Both are real, correct readings of different points on the die — hotspot is what actually drives thermal throttling and is what HWiNFO/GPU-Z treat as primary, which is why it's preferred here, but it won't match Task Manager's number exactly for the same card at the same moment.

## Testing

Windows 11, AMD Radeon RX 7900 XTX (discrete) + Intel UHD Graphics 770 (integrated), Vulkan backend, rebased onto current main (v0.13.2). Verified:
- Both GPUs show with correct name/total VRAM
- "used" and "util" track real values (confirmed against `Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory`/`GPUEngine` directly, both idle and with a 27B model loaded — 0% idle, 96% during active generation)
- AMD hotspot temperature matches AMD's own sensor reading in the same run
- Intel iGPU correctly stays at util=0/temp=0 (no regression — Task Manager doesn't show Intel temperature either)
- No crashes from the in-process ADL DLL calls across multiple engine restarts

Happy to adjust anything — this is my first contribution to the project, let me know if you'd want a different structure (e.g. squashed, or the edge/hotspot choice made configurable).