### PR TITLE
llm/chat: three chat-reliability fixes from a long-reasoning turn

### DIFF
--- a/internal/ajean/chat_conversation.go
+++ b/internal/ajean/chat_conversation.go
@@ -25,11 +25,28 @@ import (
 
 // maxLogEvents plafonne le journal d'AFFICHAGE (pas la vue modèle). Depuis la
 // coalescence en fin de tour (compactLogLocked), un tour terminé ne pèse plus
-// qu'une poignée d'événements au lieu d'un par token → 20000 couvre des
-// centaines de tours. La marge sert surtout à absorber UN tour en cours (streamé
-// token par token) avant sa coalescence : un très gros tour (long raisonnement +
-// réponse) ne doit pas se faire tronquer le début avant d'être compacté.
-const maxLogEvents = 20000
+// qu'une poignée d'événements au lieu d'un par token → cette limite couvre des
+// centaines de tours normaux. La marge sert surtout à absorber UN tour en cours
+// (streamé token par token) avant sa coalescence : un très gros tour (long
+// raisonnement + réponse) ne doit pas se faire tronquer le début avant d'être
+// compacté.
+//
+// Observé en usage réel (2026-09-02) : un tour à raisonnement prolongé (~15 670
+// tokens de réponse visible + environ 15-16 min de raisonnement pur avant, sans
+// doute plusieurs dizaines de milliers de tokens supplémentaires) a dépassé
+// l'ancienne limite de 20000 AVANT sa propre coalescence — le début de la
+// conversation (messages précédents) s'est fait tronquer du journal de rejeu,
+// invisible au rechargement de la page (toujours présent dans la conversation
+// persistée, /api/chat/export, seul le REJEU SSE en a perdu la trace). Relevé à
+// 200000 : ~20 Mo de LogEvent en pire cas, négligeable, et il faudrait un tour
+// encore ~10x plus extrême que celui observé pour re-atteindre cette limite. Pas
+// une garantie absolue dans l'infini — la fusion incrémentale (au lieu de
+// seulement en fin de tour) supprimerait le risque structurellement, mais elle
+// touche au chemin de diffusion EN DIRECT (numéros de séquence lus par
+// sort.Search côté abonnés) d'une façon qui n'a pas pu être vérifiée sans risque
+// de duplication de texte pour un onglet connecté en direct pendant un tour —
+// laissé de côté pour cette raison.
+const maxLogEvents = 200000
 
 // LogEvent = un événement d'affichage rejouable (un delta SSE + son numéro de
 // séquence monotone + un horodatage serveur en ms). Le TS permet au client de

--- a/internal/ajean/llm_client.go
+++ b/internal/ajean/llm_client.go
@@ -759,9 +759,15 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 	repeatCount := map[string]int{}
 	// Garde-fou « pensé sans agir » : certains modèles à reasoning planifient un
 	// appel d'outil dans leur <think> puis émettent le token de fin SANS l'émettre
-	// (ni réponse, ni tool_call). On relance alors UNE fois le tour avec un nudge
-	// explicite au lieu d'afficher « pas de réponse ».
-	nudged := false
+	// (ni réponse, ni tool_call) — parfois après avoir reformulé le même plan
+	// plusieurs fois sans jamais l'exécuter (observé : ~15 000 tokens de
+	// raisonnement en boucle sur une tâche complexe, zéro contenu visible). On
+	// relance alors le tour avec un nudge explicite au lieu d'afficher tout de
+	// suite « pas de réponse » — maxNudges fois, pas plus : un modèle vraiment
+	// bloqué doit finir par rendre la main plutôt que de faire attendre
+	// indéfiniment (voir le message affiché après le dernier essai).
+	const maxNudges = 2
+	nudgeCount := 0
 	// Pas de plafond d'itérations ni d'anti-boucle : ils coupaient des tours
 	// parfaitement légitimes (une recherche enchaîne facilement des dizaines
 	// d'appels, parfois identiques). Le seul frein est le bouton stop, qui annule
@@ -1415,18 +1421,23 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 		// instead of leaving the user staring at a silent, finished chat.
 		if strings.TrimSpace(assistantContent.String()) == "" {
 			// Filet de sécurité (le vrai fix est le prompt court, voir baseSystemPrompt) :
-			// si un modèle « pense sans agir » malgré tout, on le relance UNE fois avec
-			// une consigne impérative au lieu d'afficher « pas de réponse ».
-			if len(tools) > 0 && !disableTools && !nudged {
-				nudged = true
+			// si un modèle « pense sans agir » malgré tout, on le relance avec une
+			// consigne impérative au lieu d'afficher « pas de réponse » tout de suite.
+			// Le premier nudge suffit la plupart du temps ; un second, plus direct,
+			// rattrape le cas observé où le modèle re-décrit le même plan en boucle
+			// sans jamais l'exécuter — une simple reformulation de "agis" ne suffit
+			// alors plus, il faut lui interdire explicitement de re-raisonner.
+			if len(tools) > 0 && !disableTools && nudgeCount < maxNudges {
+				nudgeCount++
 				// Le raisonnement de ce tour avorté ne mène à rien : on demande à
 				// l'UI de l'effacer avant de relancer, pour ne pas afficher deux
 				// blocs de réflexion successifs.
 				cb(StreamEvent{DropReasoning: true})
-				messages = append(messages, Message{
-					Role:    "user",
-					Content: "You reasoned but did not call a tool or answer. Act NOW: call the appropriate tool directly (e.g. mem_search/mem_read/bash), or give your final answer if you already have the info. Don't explain, act.",
-				})
+				nudge := "You reasoned but did not call a tool or answer. Act NOW: call the appropriate tool directly (e.g. mem_search/mem_read/bash), or give your final answer if you already have the info. Don't explain, act."
+				if nudgeCount > 1 {
+					nudge = "You are stuck re-describing the same plan without executing it. Stop reasoning. In your NEXT message, either call ONE tool right now, or write your final answer in plain text using only what you already know — no more planning, no more thinking, act or answer this instant."
+				}
+				messages = append(messages, Message{Role: "user", Content: nudge})
 				continue
 			}
 			cb(StreamEvent{Content: "_(le modèle n'a pas produit de réponse — finish: " + finishReason + ")_"})

--- a/internal/ajean/llm_client.go
+++ b/internal/ajean/llm_client.go
@@ -732,6 +732,73 @@ func isNetTimeout(err error) bool {
 	return errors.As(err, &ne) && ne.Timeout()
 }
 
+// repetitionGuard détecte un modèle qui rabâche la même phrase dans son
+// raisonnement au lieu d'avancer — signe empirique de blocage, pas une simple
+// longue réflexion. Constaté sur ce projet en analysant deux blocages réels
+// (déchiffrage d'un atlas de police à partir d'un dump de pixels, tâche que le
+// modèle ne pouvait pas vraiment résoudre en texte seul) : dans les deux cas,
+// UNE phrase quasi identique revenait 82 puis 132 fois d'affilée, jamais
+// reformulée différemment — un match texte exact après normalisation suffit,
+// pas besoin de similarité floue. Portée : une seule complétion HTTP (voir son
+// utilisation dans runChat, réinitialisé à chaque itération) — les deux cas
+// réels tenaient chacun dans un seul appel de génération, jamais étalés sur
+// plusieurs tours d'outil.
+type repetitionGuard struct {
+	buf  strings.Builder
+	seen map[string]int
+}
+
+// repetitionGuardThreshold : nombre de répétitions EXACTES avant de couper.
+// Sur les deux cas réels le motif était déjà installé dès la 2e/3e occurrence
+// — attendre plus ne fait que gâcher des tokens (ces cas sont allés jusqu'à 82
+// et 132 répétitions avant de s'arrêter tout seuls).
+const repetitionGuardThreshold = 3
+
+// repetitionGuardMinLen : ignore les phrases courtes (« Let me check. », « OK,
+// next. ») qui reviennent légitimement sans être un signe de blocage — seules
+// les phrases assez longues pour porter une vraie idée comptent.
+const repetitionGuardMinLen = 40
+
+// feed avale un morceau de texte (delta de streaming) et détecte, phrase par
+// phrase (coupée sur . ! ? ou saut de ligne), une répétition. looping=true dès
+// que la MÊME phrase normalisée atteint repetitionGuardThreshold occurrences ;
+// sentence porte alors cette phrase (pour l'expliquer au modèle ensuite).
+func (g *repetitionGuard) feed(chunk string) (looping bool, sentence string) {
+	if g.seen == nil {
+		g.seen = map[string]int{}
+	}
+	g.buf.WriteString(chunk)
+	for {
+		s := g.buf.String()
+		idx := strings.IndexAny(s, ".!?\n")
+		if idx < 0 {
+			break
+		}
+		raw := s[:idx+1]
+		g.buf.Reset()
+		g.buf.WriteString(s[idx+1:])
+		norm := strings.Join(strings.Fields(strings.ToLower(raw)), " ")
+		if len(norm) < repetitionGuardMinLen {
+			continue
+		}
+		g.seen[norm]++
+		if g.seen[norm] >= repetitionGuardThreshold {
+			return true, strings.TrimSpace(raw)
+		}
+	}
+	return false, ""
+}
+
+// truncateRunes coupe s à n runes (jamais en plein milieu d'un caractère
+// multi-octets), avec une ellipse si tronqué.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 func runChat(ctx context.Context, messages []Message, temperature float64, caps Caps, cb ChatCallback) ([]Message, error) {
 	var extra []Message
 	tools := EnabledTools(caps)
@@ -757,15 +824,22 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 	// la réponse progressivement (voir repeatedCallResult) : rendre le contenu une
 	// fois, puis refuser en le renvoyant vers ce qu'il a déjà.
 	repeatCount := map[string]int{}
-	// Garde-fou « pensé sans agir » : certains modèles à reasoning planifient un
-	// appel d'outil dans leur <think> puis émettent le token de fin SANS l'émettre
-	// (ni réponse, ni tool_call) — parfois après avoir reformulé le même plan
-	// plusieurs fois sans jamais l'exécuter (observé : ~15 000 tokens de
-	// raisonnement en boucle sur une tâche complexe, zéro contenu visible). On
-	// relance alors le tour avec un nudge explicite au lieu d'afficher tout de
-	// suite « pas de réponse » — maxNudges fois, pas plus : un modèle vraiment
-	// bloqué doit finir par rendre la main plutôt que de faire attendre
-	// indéfiniment (voir le message affiché après le dernier essai).
+	// Garde-fou « le modèle est coincé » : deux signes distincts partagent le
+	// même compteur/plafond, ce sont deux symptômes du même problème. (1) pensé
+	// sans agir : certains modèles à reasoning planifient un appel d'outil dans
+	// leur <think> puis émettent le token de fin SANS l'émettre (ni réponse, ni
+	// tool_call) — parfois après avoir reformulé le même plan plusieurs fois sans
+	// jamais l'exécuter (observé : ~15 000 tokens de raisonnement en boucle sur
+	// une tâche complexe, zéro contenu visible). (2) répétition mécanique
+	// détectée EN COURS de flux par repetitionGuard (voir son commentaire et son
+	// utilisation plus bas) : deux blocages réels analysés montraient une phrase
+	// quasi identique revenant 82 puis 132 fois — (1) seul ne les aurait jamais
+	// interrompus puisque le modèle finit par émettre un finish_reason normal
+	// après avoir tout dit, juste beaucoup trop tard. Dans les deux cas on
+	// relance le tour avec un nudge explicite au lieu d'afficher tout de suite
+	// « pas de réponse » — maxNudges fois, pas plus : un modèle vraiment bloqué
+	// doit finir par rendre la main plutôt que de faire attendre indéfiniment
+	// (voir le message affiché après le dernier essai).
 	const maxNudges = 2
 	nudgeCount := 0
 	// Pas de plafond d'itérations ni d'anti-boucle : ils coupaient des tours
@@ -889,6 +963,11 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 		sawReasoningField := false
 		thinkOpen := reasoningOn
 		var thinkTail strings.Builder
+		// Anti-boucle : réinitialisé à CHAQUE complétion (voir repetitionGuard) —
+		// une répétition détectée ici coupe la lecture du flux plus bas.
+		var loopGuard repetitionGuard
+		loopDetected := false
+		loopSentence := ""
 		// Scanner à gros tampon : un chunk peut porter un gros JSON d'arguments
 		// (écriture de fichier). 8 Mio et non 1 : au-delà du tampon, le scanner
 		// s'arrête sur « token too long » AU MILIEU du flux, et jusqu'à la 0.8.4
@@ -1026,6 +1105,11 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 					aborted = true
 					break
 				}
+				if looping, sentence := loopGuard.feed(ch.Delta.ReasoningContent); looping {
+					loopDetected = true
+					loopSentence = sentence
+					break
+				}
 			}
 			if ch.Delta.Content != "" {
 				assistantContent.WriteString(ch.Delta.Content)
@@ -1106,6 +1190,25 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 			err := streamCutError(scanErr)
 			cb(StreamEvent{Err: err})
 			return extra, err
+		}
+
+		// Le modèle rabâchait la même phrase (voir repetitionGuard) : on a coupé la
+		// lecture du flux tôt (dès la 3e répétition, pas après des dizaines) plutôt
+		// que d'attendre une fin de tour normale qui n'allait pas venir. Les appels
+		// d'outils accumulés jusque-là (s'il y en a) sont abandonnés avec le reste :
+		// une répétition en cours de <think> n'a rien produit d'exploitable.
+		if loopDetected {
+			if nudgeCount < maxNudges {
+				nudgeCount++
+				cb(StreamEvent{DropReasoning: true})
+				messages = append(messages, Message{
+					Role: "user",
+					Content: "You've repeated the same point several times in a row without making progress (\"" + truncateRunes(loopSentence, 180) + "\") — that's a sign this approach is stuck. Drop it: try something concretely different (a different method, tool, or angle), or if you already know enough, give your answer now. Don't repeat that reasoning again.",
+				})
+				continue
+			}
+			cb(StreamEvent{Content: "_(le modèle tournait en boucle sur la même idée — arrêté après " + strconv.Itoa(repetitionGuardThreshold) + " répétitions)_"})
+			return extra, nil
 		}
 
 		// Treat any accumulated tool calls as a tool turn even if the backend set

--- a/internal/ajean/llm_client_repetition_test.go
+++ b/internal/ajean/llm_client_repetition_test.go
@@ -1,0 +1,93 @@
+package ajean
+
+import "testing"
+
+func TestRepetitionGuardIgnoresDistinctSentences(t *testing.T) {
+	var g repetitionGuard
+	sentences := []string{
+		"I'm going to read the first ten bytes of the header to check the magic number.",
+		"That confirms it's a valid GGUF file, version three as expected.",
+		"Now let me look at the tensor count and the metadata key-value count.",
+		"The architecture key says qwen35, which matches what I saw earlier.",
+	}
+	for _, s := range sentences {
+		if looping, _ := g.feed(s + " "); looping {
+			t.Fatalf("distinct sentence wrongly flagged as a loop: %q", s)
+		}
+	}
+}
+
+func TestRepetitionGuardTriggersAtThreshold(t *testing.T) {
+	var g repetitionGuard
+	sentence := "I'm realizing the atlas layout is more complex than a simple grid, glyphs have varying heights and positions."
+	for i := 1; i < repetitionGuardThreshold; i++ {
+		if looping, _ := g.feed(sentence + " "); looping {
+			t.Fatalf("triggered too early, on repeat #%d (threshold is %d)", i, repetitionGuardThreshold)
+		}
+	}
+	looping, got := g.feed(sentence + " ")
+	if !looping {
+		t.Fatalf("expected loop detection on repeat #%d, got none", repetitionGuardThreshold)
+	}
+	if got == "" {
+		t.Fatal("expected the detected sentence to be returned, got empty string")
+	}
+}
+
+func TestRepetitionGuardIgnoresShortFiller(t *testing.T) {
+	var g repetitionGuard
+	// "Let me check." et "OK, next." reviennent légitimement dans un raisonnement
+	// normal sans jamais signaler un blocage — repetitionGuardMinLen doit les
+	// écarter même répétées bien plus de repetitionGuardThreshold fois.
+	for i := 0; i < 10; i++ {
+		if looping, _ := g.feed("Let me check. "); looping {
+			t.Fatalf("short filler sentence wrongly flagged as a loop on iteration %d", i)
+		}
+	}
+}
+
+func TestRepetitionGuardNormalizesWhitespaceAndCase(t *testing.T) {
+	var g repetitionGuard
+	variants := []string{
+		"This is a fairly long sentence about the font atlas layout that repeats.",
+		"THIS IS A FAIRLY LONG SENTENCE ABOUT THE FONT ATLAS LAYOUT THAT REPEATS.",
+		"This   is  a fairly long   sentence about the font atlas layout that repeats.",
+	}
+	for i, v := range variants {
+		looping, _ := g.feed(v + " ")
+		if i < repetitionGuardThreshold-1 && looping {
+			t.Fatalf("triggered too early on variant %d", i)
+		}
+		if i == repetitionGuardThreshold-1 && !looping {
+			t.Fatalf("case/whitespace variants weren't recognized as the same sentence")
+		}
+	}
+}
+
+// TestRepetitionGuardOnRealLoopTranscript rejoue (en abrégé) le motif observé
+// dans un vrai blocage capturé en production : la même phrase quasi identique
+// revenait des dizaines de fois dans le raisonnement d'un modèle coincé sur un
+// déchiffrage d'atlas de police. Vérifie que le détecteur aurait coupé net à
+// la 3e occurrence plutôt que de laisser filer jusqu'à la 82e comme ce jour-là.
+func TestRepetitionGuardOnRealLoopTranscript(t *testing.T) {
+	var g repetitionGuard
+	real := "I'm realizing the atlas might not follow a simple row-based structure—band1 has 16 glyphs while band0 has 8, which breaks the pattern I was assuming."
+	other := "This suggests the font atlas uses a bin-packing algorithm that groups glyphs by height rather than following a fixed grid."
+	// Le vrai transcript alternait deux phrases qui revenaient chacune ~80 fois ;
+	// on ne rejoue que les 5 premiers tours pour vérifier le déclenchement précoce.
+	turns := []string{real, other, real, other, real}
+	triggeredAt := -1
+	for i, s := range turns {
+		if looping, _ := g.feed(s + " "); looping {
+			triggeredAt = i
+			break
+		}
+	}
+	// real apparaît aux index 0, 2, 4 (1re, 2e, 3e occurrence) — le déclenchement
+	// attendu est donc à l'index 4, pas 2 : la garde compte par phrase normalisée,
+	// pas par position, donc "other" intercalé entre les occurrences ne la trompe
+	// pas (mais ne l'accélère pas non plus).
+	if triggeredAt != 4 {
+		t.Fatalf("expected the guard to trigger on the 3rd occurrence of `real` (index 4), got index %d", triggeredAt)
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes, both found while investigating the same real session: a task with a genuinely hard sub-problem (mapping 139 glyphs from a game's custom font format) drove the model into an unusually long turn — ~15,670 tokens of visible content plus roughly 15-16 minutes of pure reasoning before it.

### 1. Second, sharper nudge when a turn reasons but never answers

The model spent most of that turn re-describing the same plan several times ("Let me build a labeled contact sheet...", "Let me dump the glyphs as ASCII art...", "Let me render each glyph...") without ever calling a tool or emitting visible content. The existing single automatic nudge ("act now") fired once and still wasn't enough — the turn ended showing the raw fallback message (`_(le modèle n'a pas produit de réponse — finish: stop)_`) to the user, even though a plain manual follow-up message got a fully coherent, useful answer immediately after.

`nudged bool` → `nudgeCount` with `maxNudges = 2`. The first automatic nudge is unchanged. If the model is still stuck after it, a second, more explicit nudge fires instead of repeating the same phrasing that already failed once:

> "You are stuck re-describing the same plan without executing it. Stop reasoning. In your NEXT message, either call ONE tool right now, or write your final answer in plain text using only what you already know — no more planning, no more thinking, act or answer this instant."

Deliberately still bounded, not unlimited: a genuinely stuck model should eventually hand back control. Tradeoff: a real block now takes roughly twice as long to surface the fallback message.

### 2. Raise the SSE display-log cap (`maxLogEvents`)

`maxLogEvents` (20000) bounds the replay log used to reconstruct the chat UI on reconnect/reload. It's only compacted (coalesced into a handful of events per turn) at `turn_done` — so a turn still streaming can grow one raw event per token before that point. The turn above exceeded 20000 raw events before its own compaction ran, truncating the *oldest* entries — the earlier part of the conversation dropped out of the replay log (invisible until the next reload). The underlying conversation data itself was never at risk — confirmed intact via `/api/chat/export` and `history/restore` — only the SSE replay view lost track of it.

Raised to 200000 (~20MB worst case, negligible) as a low-risk mitigation: a turn would need to be roughly 10x more extreme than the one observed to hit this again. Not an absolute guarantee — an incremental merge (coalescing as each token streams in, not just at `turn_done`) would close the gap structurally, but that touches the live-subscriber delivery path (Seq-based `sort.Search`) in a way that risks duplicating text for anyone connected mid-turn if not handled very carefully. Left alone rather than risk introducing a more visible bug while fixing a rarer one — flagging this explicitly in case you'd rather take that approach.

### 3. Detect a model repeating itself mid-reasoning, not just after the fact (added later, same investigation)

Fix #1 above only catches a stuck turn once it finishes with empty content — it still burns through the whole generation first. Digging into this project's own chat history (the same fork's real usage) turned up something more specific than "long reasoning": two separate real incidents each had the model repeat one near-identical reasoning sentence 82 and 132 times respectively before finally stopping on its own — 15,670 and 18,382 tokens spent on a single generation that produced nothing usable. Both were the exact same underlying task (mapping glyphs from a raw pixel/font dump — a task a text-only reasoning model structurally can't solve well without a vision projector, which is a separate, orthogonal fix on this same fork).

`repetitionGuard` watches the `reasoning_content` stream sentence-by-sentence (split on `.`/`!`/`?`/newline) and flags a loop the moment ANY normalized sentence repeats 3 times — verified against the actual repeated text from both real incidents, which would have cut them off within the first few hundred tokens instead of tens of thousands (5 unit tests, including one replaying the literal repeated sentence from the real transcript).

On detection, the in-flight request is aborted (mirrors the existing user-stop `aborted` path, but falls through to the retry logic instead of returning early) and the model gets a nudge naming the exact sentence it was stuck on, sharing the same `nudgeCount`/`maxNudges` budget as fix #1 — two symptoms of the same underlying problem, one shared retry cap rather than two independent ones that could compound.

## Scope note

Unrelated to the i18n/GPU work from another branch/PR (#59) from the same fork — kept separate per your usual one-topic-per-PR style.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` clean (one unrelated pre-existing failure: `TestMCPEndToEnd`, needs network access to fetch an npm-hosted MCP server — confirmed unrelated by inspection, not caused by either change here).
- Fix #2 verified end-to-end: reproduced the truncated replay live (raw SSE fetch showed content starting mid-sentence, not from the conversation start), deployed the fix, confirmed a full page reload now restores the complete conversation (checked via DOM inspection + screenshot, all 9 rendered messages, correct token/context counts).
- Fix #1 (nudge retry) is a targeted, reasoned fix for an observed failure mode rather than one verified against a fresh live repro of the exact original trigger (it emerged from an open-ended agentic task, not a deterministic input) — flagging this rather than overstating verification.
- Fix #3 (repetition guard): 5 new unit tests, including one replaying the literal repeated sentence pulled from a real incident's transcript and confirming it triggers on the 3rd occurrence rather than the ~80-130 it took to stop on its own. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
