### PR TITLE
test: fix two pre-existing, unrelated CI failures

### DIFF
--- a/internal/ajean/chat_prompt_size_test.go
+++ b/internal/ajean/chat_prompt_size_test.go
@@ -40,7 +40,12 @@ import (
 // toute sa navigation par niveaux vit dans SES RÉPONSES, pas dans le prompt (une
 // seule ligne de consigne : « ça va dans suivi, pas dans une note »). Ajout demandé
 // et accepté ; il sort au contraire le suivi des notes .md, qui restent petites.
-const promptCharBudget = 10800 // ~2700 tokens, tout allumé (agent+web+mémoire+suivi)
+//
+// Correction (10800 → 10900), sans ajout : la mesure au moment du relèvement
+// précédent était de 59 caractères courte du total réel (10859), ce test
+// échouait donc déjà à froid, avant tout nouvel outil. Vérifié sur un checkout
+// propre d'origin/main — aucun outil ni config locale (MCP compris) en cause.
+const promptCharBudget = 10900 // ~2725 tokens, tout allumé (agent+web+mémoire+suivi)
 
 func TestSystemPromptStaysLean(t *testing.T) {
 	caps := Caps{Agent: true, Internet: true, Mem: MemAlways}

--- a/internal/ajean/chat_recall_test.go
+++ b/internal/ajean/chat_recall_test.go
@@ -1,9 +1,47 @@
 package ajean
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
+
+// summarizerStub sert une réponse de résumé non-streamée canée (voir
+// summarizeTranscript) et pointe PORT vers lui — sans ça, TestCompactArchivesBigBlock
+// dépend d'un VRAI llama-server sur cette machine (LLMPort() en dur), ce qui le
+// rend instable dès que ce serveur est lent/occupé (par ex. un autre modèle
+// chargé en parallèle pour un usage réel) : la compaction retombe alors sur le
+// repli dégraissé au lieu du résumé, qui peut ne pas atteindre les ~20% de
+// réduction exigés, et le test échoue par « rien n'a changé » — sans rapport
+// avec le comportement testé. Même pattern que sseCuttingServer
+// (llm_stream_cut_test.go) pour un autre point d'entrée LLM.
+func summarizerStub(t *testing.T, summary string) {
+	t.Helper()
+	// Encode juste le texte pour un échappement JSON correct (guillemets, retours
+	// à la ligne…), puis l'insère dans la forme attendue par summarizeTranscript
+	// (voir summarizeResp) — plus simple que de reconstruire son struct anonyme
+	// imbriqué pour un littéral composite.
+	quoted, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := []byte(`{"choices":[{"message":{"content":` + string(quoted) + `}}]}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SetConfigKey("PORT", u.Port()); err != nil {
+		t.Fatal(err)
+	}
+}
 
 // Archive puis rappel : le bloc doit revenir VERBATIM, à l'octet près.
 func TestRecallRoundtrip(t *testing.T) {
@@ -57,10 +95,19 @@ func TestRecallSearchFindsByKeyword(t *testing.T) {
 
 // Intégration : pendant une compaction en mode agent, un gros bloc du torse est
 // archivé et récupérable, et l'historique compacté le référence par recall(id)
-// au lieu de l'effacer. (summarizeTranscript échoue faute de llama-server → on
-// tombe sur le repli dégraissé, qui porte justement les marqueurs recall.)
+// au lieu de l'effacer.
+//
+// summarizerStub pointe PORT vers un faux serveur plutôt que de compter sur
+// l'absence de llama-server dans l'environnement de test : sur une machine où
+// un VRAI moteur tourne par ailleurs (développement courant de ce projet — un
+// modèle chargé pour un usage réel pendant que `go test` tourne), summarizeTranscript
+// pouvait aboutir ou traîner selon la charge de ce serveur, au lieu d'échouer
+// proprement — rendant ce test instable pour une raison sans rapport avec ce
+// qu'il vérifie. Voir aussi sseCuttingServer (llm_stream_cut_test.go), même
+// pattern pour un autre point d'entrée LLM.
 func TestCompactArchivesBigBlock(t *testing.T) {
-	t.Setenv("AJEAN_HOME", t.TempDir())
+	testHome(t)
+	summarizerStub(t, "Résumé de test : le fil demandait un jeu en Go ; du code a été écrit puis ajusté plusieurs fois, rien d'autre à retenir.")
 	bigCode := "func jeu(){\n" + strings.Repeat("  ligne_de_code_unique_wibble\n", 60) + "}"
 	msgs := []Message{
 		um("fais-moi un jeu en go"),


### PR DESCRIPTION
## Summary
- `TestSystemPromptStaysLean`: the last budget bump (9600 -> 10800, for the tracker tool) landed 59 chars under the actual measured preamble size. Confirmed on a clean `origin/main` checkout — nothing grew, the number was just off. Corrected to 10900.
- `TestCompactArchivesBigBlock`: relied on `summarizeTranscript` failing (no llama-server reachable) to exercise its pruned-fallback path. On a dev machine running this project's own ajean with a real model loaded — the normal case while iterating on it locally — the test's summarize call hits that real server instead, so it sometimes succeeds, sometimes drags under load, making the compaction's 20%-reduction check timing-dependent instead of deterministic. Now stubs the LLM endpoint with a local httptest server (same pattern as `sseCuttingServer` in `llm_stream_cut_test.go`). Went from ~3.5-4.7s to ~0.1s, stable across repeated full-suite runs.

Neither failure is related to any other change — found while double-checking an unrelated feature branch's test run.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/ajean/...`
- [x] `go test ./internal/ajean/...` — both tests pass individually and under 3x full-suite runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)