### PR TITLE
ui: saving the active preset's settings now restarts the service

### DIFF
--- a/internal/ajean/ui/index.html
+++ b/internal/ajean/ui/index.html
@@ -4265,6 +4265,15 @@ async function runBenchUI(){
 }
 async function switchTo(n,name){
   if(!await askConfirm('Basculer vers « '+name+' » et redémarrer le service ?', {title:'Changer de preset', okText:'Basculer'})) return;
+  await applyPresetSwitch(n);
+}
+// Bascule effective vers le preset n (1-based), SANS confirmation — factorisé
+// hors de switchTo() pour que saveItem() puisse la réutiliser après avoir
+// enregistré le preset ACTIF : sauvegarder ses réglages ne relançait pas le
+// moteur, seul un clic sur la ligne (donc rebasculer sur lui-même) le faisait.
+// Un utilisateur qui vient de choisir un mmproj puis cliqué « enregistrer » n'a
+// pas à redemander confirmation pour appliquer ce qu'il vient d'accepter.
+async function applyPresetSwitch(n){
   toast('switching…');
   // Retour visuel IMMÉDIAT : la ligne visée s'allume et clignote. Le serveur met
   // plusieurs secondes à redémarrer le service ; sans ça la liste ne bougeait pas
@@ -5258,6 +5267,20 @@ async function saveItem(){
     : {name, old: editingKey, content};
   const r = await jpost(K.saveUrl, payload);
   if(!r.ok){ toast('erreur : ' + (r.error||'')); return; }
+  // Enregistrer les réglages du preset ACTIF ne les applique pas tout seul : le
+  // moteur tourne déjà avec l'ancienne config tant qu'on ne rebascule pas dessus
+  // (switchTo). Sans ça, un changement qui doit relancer llama-server (modèle,
+  // CTX, mmproj…) reste sans effet malgré le "enregistré", et il faut cliquer la
+  // ligne du preset une deuxième fois pour qu'il se passe quelque chose.
+  if(editingKind==='preset' && editingKey){
+    const presets = await jget('/api/presets');
+    const idx = presets.findIndex(p => p.id===editingKey);
+    if(idx>=0 && presets[idx].active){
+      closeModal();
+      await applyPresetSwitch(idx+1);
+      return;
+    }
+  }
   toast('enregistré'); closeModal(); K.reload();
 }
 async function delItem(){

--- a/internal/ajean/ui/src/js/07-models.js
+++ b/internal/ajean/ui/src/js/07-models.js
@@ -43,6 +43,15 @@ async function runBenchUI(){
 }
 async function switchTo(n,name){
   if(!await askConfirm('Basculer vers « '+name+' » et redémarrer le service ?', {title:'Changer de preset', okText:'Basculer'})) return;
+  await applyPresetSwitch(n);
+}
+// Bascule effective vers le preset n (1-based), SANS confirmation — factorisé
+// hors de switchTo() pour que saveItem() puisse la réutiliser après avoir
+// enregistré le preset ACTIF : sauvegarder ses réglages ne relançait pas le
+// moteur, seul un clic sur la ligne (donc rebasculer sur lui-même) le faisait.
+// Un utilisateur qui vient de choisir un mmproj puis cliqué « enregistrer » n'a
+// pas à redemander confirmation pour appliquer ce qu'il vient d'accepter.
+async function applyPresetSwitch(n){
   toast('switching…');
   // Retour visuel IMMÉDIAT : la ligne visée s'allume et clignote. Le serveur met
   // plusieurs secondes à redémarrer le service ; sans ça la liste ne bougeait pas
@@ -1036,6 +1045,20 @@ async function saveItem(){
     : {name, old: editingKey, content};
   const r = await jpost(K.saveUrl, payload);
   if(!r.ok){ toast('erreur : ' + (r.error||'')); return; }
+  // Enregistrer les réglages du preset ACTIF ne les applique pas tout seul : le
+  // moteur tourne déjà avec l'ancienne config tant qu'on ne rebascule pas dessus
+  // (switchTo). Sans ça, un changement qui doit relancer llama-server (modèle,
+  // CTX, mmproj…) reste sans effet malgré le "enregistré", et il faut cliquer la
+  // ligne du preset une deuxième fois pour qu'il se passe quelque chose.
+  if(editingKind==='preset' && editingKey){
+    const presets = await jget('/api/presets');
+    const idx = presets.findIndex(p => p.id===editingKey);
+    if(idx>=0 && presets[idx].active){
+      closeModal();
+      await applyPresetSwitch(idx+1);
+      return;
+    }
+  }
   toast('enregistré'); closeModal(); K.reload();
 }
 async function delItem(){


### PR DESCRIPTION
## Summary
Saving the currently-active preset's settings (picking a vision projector, changing CTX, etc.) only wrote the change to storage — the running llama-server kept using the old config until the preset row was clicked a second time (which is really "switch to itself", but it's the only path that calls `/api/switch`). The save button's own "enregistré" toast made it look like the change had already taken effect.

`applyPresetSwitch()` factors `switchTo()`'s actual apply-and-restart logic out from its confirmation dialog. `saveItem()` now calls it directly (no dialog — the user already made an explicit save action) when the saved preset is the one currently active. Saving an inactive preset is unaffected.

Verified live in the browser: saving the active preset's settings now triggers the restart immediately, no second click, no confirmation prompt.

## Test plan
- [x] `go build ./...`
- [x] Manual test in-browser: edited the active preset's Vision projector, clicked "enregistrer" — service restarted automatically, model + mmproj reloaded, no second click needed
- [x] Saving an inactive preset still just saves (no restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)