### PR TITLE
chat: stop silently losing images from context on compaction

### DIFF
--- a/internal/ajean/chat_compact.go
+++ b/internal/ajean/chat_compact.go
@@ -100,11 +100,28 @@ func compactSummaryBudget() int {
 	return n
 }
 
+// imageLostMarker remplace la partie `image_url` d'un message multimodal dans
+// msgText : ni recallEligible ni le résumeur ne voient jamais l'image elle-même
+// (msgText n'en extrait que le texte), donc SANS ce marqueur un message
+// see_image ne pèse que sa légende (« Image demandée (fichier) : »), largement
+// sous recallArchiveMinLen — il n'est jamais archivé, et le résumeur ne sait
+// même pas qu'une image a été montrée. Au compactage suivant, l'image
+// disparaît donc du contexte SANS AUCUNE trace : ni bloc recall, ni mention
+// dans le résumé — observé en usage réel comme cause probable de boucles de
+// raisonnement (le modèle a bien regardé une image de police/pixels, mais ne
+// peut plus s'y référer après compaction et redérive à l'aveugle en texte).
+// Ce marqueur ne rend pas l'image rappelable (recall reste du texte pur), mais
+// il rend sa PERTE visible : le résumeur peut la mentionner dans sa prose, et
+// le modèle sait qu'il doit rappeler see_image plutôt que de deviner.
+const imageLostMarker = " [image — not kept past this point in the conversation once summarized; call see_image on the same file again if you still need to see it]"
+
 // msgText extrait le texte d'un message (Content est `any`, en pratique string
 // ou nil quand l'assistant n'a que des tool_calls). Un message multimodal
 // (userMessageContent : parties texte + image quand la vision est active) porte
 // un tableau de parties ; on en recolle les segments `text` pour que l'estimation
-// de contexte et le transcript de compaction ne partent pas d'un texte vide.
+// de contexte et le transcript de compaction ne partent pas d'un texte vide, et
+// on marque la présence d'une partie `image_url` (voir imageLostMarker) — sans
+// quoi elle est invisible à toute la chaîne de compaction.
 func msgText(m Message) string {
 	switch v := m.Content.(type) {
 	case string:
@@ -112,20 +129,30 @@ func msgText(m Message) string {
 	case []map[string]any:
 		var b strings.Builder
 		for _, part := range v {
-			if part["type"] == "text" {
+			switch part["type"] {
+			case "text":
 				if s, ok := part["text"].(string); ok {
 					b.WriteString(s)
 				}
+			case "image_url":
+				b.WriteString(imageLostMarker)
 			}
 		}
 		return b.String()
 	case []any: // même contenu relu depuis le JSON persisté (map générique)
 		var b strings.Builder
 		for _, p := range v {
-			if part, ok := p.(map[string]any); ok && part["type"] == "text" {
+			part, ok := p.(map[string]any)
+			if !ok {
+				continue
+			}
+			switch part["type"] {
+			case "text":
 				if s, ok := part["text"].(string); ok {
 					b.WriteString(s)
 				}
+			case "image_url":
+				b.WriteString(imageLostMarker)
 			}
 		}
 		return b.String()

--- a/internal/ajean/chat_compact_image_test.go
+++ b/internal/ajean/chat_compact_image_test.go
@@ -1,0 +1,83 @@
+package ajean
+
+import (
+	"strings"
+	"testing"
+)
+
+// imgMsg reproduit la forme réelle du message injecté après un see_image
+// réussi (voir llm_client.go, juste après l'exécution de l'outil) : un
+// message user multimodal, légende texte + partie image_url.
+func imgMsg(label string) Message {
+	return Message{Role: "user", Content: []map[string]any{
+		{"type": "text", "text": "Image demandée (" + label + ") :"},
+		{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,ZmFrZQ=="}},
+	}}
+}
+
+// TestMsgTextSurfacesImagePresence est le test qui aurait dû exister avant :
+// sans le marqueur, msgText() sur un message see_image ne renvoyait QUE la
+// légende ("Image demandée (fichier) :"), quelques dizaines de caractères —
+// bien sous recallArchiveMinLen (800). L'image n'était donc jamais archivée
+// NI mentionnée au résumeur : au compactage suivant, elle disparaissait sans
+// laisser une seule trace dans tout le pipeline de compaction.
+func TestMsgTextSurfacesImagePresence(t *testing.T) {
+	m := imgMsg("atlas_grid.png")
+	got := msgText(m)
+	if !strings.Contains(got, "atlas_grid.png") {
+		t.Fatalf("msgText a perdu le nom du fichier : %q", got)
+	}
+	if !strings.Contains(got, "image") {
+		t.Fatalf("msgText ne signale plus la présence d'une image : %q", got)
+	}
+}
+
+// TestMsgTextHandlesReloadedImageContent couvre le second type de Content
+// possible pour le même message une fois relu depuis le JSON persisté
+// ([]any de map[string]any générique plutôt que []map[string]any typé) — les
+// deux chemins de msgText doivent traiter image_url pareil.
+func TestMsgTextHandlesReloadedImageContent(t *testing.T) {
+	m := Message{Role: "user", Content: []any{
+		map[string]any{"type": "text", "text": "Image demandée (verify_map.png) :"},
+		map[string]any{"type": "image_url", "image_url": map[string]any{"url": "data:image/png;base64,ZmFrZQ=="}},
+	}}
+	got := msgText(m)
+	if !strings.Contains(got, "verify_map.png") || !strings.Contains(got, "image") {
+		t.Fatalf("chemin []any : marqueur image absent ou nom de fichier perdu : %q", got)
+	}
+}
+
+// TestImageMessageStillNotRecallEligible vérifie que le correctif ne change
+// PAS ce point : une image reste sous le seuil d'archivage (le marqueur est
+// court exprès) — on ne prétend pas la rendre rappelable via recall(id), on
+// rend juste sa perte visible. Voir imageLostMarker.
+func TestImageMessageStillNotRecallEligible(t *testing.T) {
+	if recallEligible(imgMsg("atlas_grid.png")) {
+		t.Fatal("un message-image est devenu éligible à l'archivage — pas l'objectif de ce correctif")
+	}
+}
+
+// TestRenderTranscriptMentionsLostImage est le test qui compte vraiment pour
+// le bug observé : le RÉSUMEUR (qui ne voit que renderTranscript, jamais les
+// messages bruts) doit pouvoir savoir qu'une image a été montrée, pour au
+// moins le dire dans son résumé — avant ce correctif, cette information
+// n'existait nulle part dans le texte qu'on lui envoie.
+func TestRenderTranscriptMentionsLostImage(t *testing.T) {
+	// Le message-image SEUL, sans le résultat d'outil texte qui le précède
+	// d'habitude — celui-là mentionne déjà "image"/le nom de fichier de son
+	// côté, ce qui aurait fait passer ce test même sans le correctif (repéré en
+	// écrivant ce test : premier jet faux-positif, corrigé pour isoler ce qu'on
+	// vérifie vraiment — que la partie image_url ELLE-MÊME laisse une trace).
+	torso := []Message{
+		um("montre-moi l'atlas"),
+		imgMsg("atlas_grid.png"),
+		am("je vois les bandes h8 et h3."),
+	}
+	out := renderTranscript(torso)
+	if !strings.Contains(out, "atlas_grid.png") {
+		t.Fatalf("le transcript envoyé au résumeur a perdu le nom du fichier vu : %q", out)
+	}
+	if !strings.Contains(out, "image") {
+		t.Fatalf("le transcript envoyé au résumeur ne mentionne plus qu'une image a été montrée : %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

`msgText()` — the function every compaction decision runs through (archiving eligibility, the summarizer's input, tool-result pruning, the "pending request" reinjection scan) — only ever extracted `type: "text"` parts from a multimodal message. It silently ignored `image_url` parts entirely.

That's exactly what a `see_image` result gets wrapped in (the `imgMsg` injection in `llm_client.go`): a short text caption ("Image demandée (file.png) :") plus the actual image. Once compaction reaches that message, `msgText` saw only the ~30-40 char caption — far under `recallArchiveMinLen` (800) — so the image was never archived, and the summarizer never even knew one had been shown (it only sees `renderTranscript`'s output, itself built from `msgText`). The image just vanished at the next compaction: no recall block, no mention in the summary, nothing.

Traced this from a real session: the model called `see_image` successfully 12 times over one long conversation (16 compactions along the way), yet its live context currently holds zero images — and it kept re-deriving pixel-level hypotheses in text, hitting the same repetition-loop safety net (from #60) repeatedly on a font-glyph-decoding task. It wasn't failing to use vision; vision's results just didn't survive context compaction.

## What this does (and doesn't do)

This doesn't make images recall-eligible — `imageLostMarker` is deliberately short, and recall stores text, not images, so pretending otherwise would be misleading. It makes the **loss visible instead of silent**: the summarizer can now mention that an image was shown and is gone, and the model knows to call `see_image` again rather than quietly losing its visual grounding and drifting back into unverifiable text reasoning. Bigger fixes (keeping recent images out of the compacted torso entirely, or making them genuinely recallable) are real options but a larger change to the compaction pipeline — flagging this as the minimal, low-risk fix for the silent-loss part specifically.

## Testing

- `go build ./...`, `go vet ./internal/ajean/...` clean.
- 4 new tests, verified against the pre-fix code first (3 fail without the fix, 1 is a deliberate "should stay false" guard that correctly passes both ways):
  - `msgText` surfaces both the filename and an image marker, for both `Content` shapes a message can have (`[]map[string]any` live, `[]any` once reloaded from persisted JSON).
  - `recallEligible` stays `false` for an image message — confirms this fix doesn't change that (unchanged on purpose).
  - `renderTranscript` (what the summarizer actually reads) mentions the image and its filename, isolated from any preceding tool-result text that might coincidentally already contain the filename.
- Full suite green aside from two pre-existing, unrelated failures: the prompt-budget test already fixed on #61, and `TestMCPEndToEnd` (network/npm-dependent, passes in isolation, flaky under full-suite load — confirmed by re-running it alone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)