### PR TITLE
llm: detect a model repeating itself mid-reasoning (single topic, extracted from #60)

### DIFF
--- a/internal/ajean/llm_client.go
+++ b/internal/ajean/llm_client.go
@@ -732,6 +732,73 @@ func isNetTimeout(err error) bool {
 	return errors.As(err, &ne) && ne.Timeout()
 }
 
+// repetitionGuard détecte un modèle qui rabâche la même phrase dans son
+// raisonnement au lieu d'avancer — signe empirique de blocage, pas une simple
+// longue réflexion. Constaté sur ce projet en analysant deux blocages réels
+// (déchiffrage d'un atlas de police à partir d'un dump de pixels, tâche que le
+// modèle ne pouvait pas vraiment résoudre en texte seul) : dans les deux cas,
+// UNE phrase quasi identique revenait 82 puis 132 fois d'affilée, jamais
+// reformulée différemment — un match texte exact après normalisation suffit,
+// pas besoin de similarité floue. Portée : une seule complétion HTTP (voir son
+// utilisation dans runChat, réinitialisé à chaque itération) — les deux cas
+// réels tenaient chacun dans un seul appel de génération, jamais étalés sur
+// plusieurs tours d'outil.
+type repetitionGuard struct {
+	buf  strings.Builder
+	seen map[string]int
+}
+
+// repetitionGuardThreshold : nombre de répétitions EXACTES avant de couper.
+// Sur les deux cas réels le motif était déjà installé dès la 2e/3e occurrence
+// — attendre plus ne fait que gâcher des tokens (ces cas sont allés jusqu'à 82
+// et 132 répétitions avant de s'arrêter tout seuls).
+const repetitionGuardThreshold = 3
+
+// repetitionGuardMinLen : ignore les phrases courtes (« Let me check. », « OK,
+// next. ») qui reviennent légitimement sans être un signe de blocage — seules
+// les phrases assez longues pour porter une vraie idée comptent.
+const repetitionGuardMinLen = 40
+
+// feed avale un morceau de texte (delta de streaming) et détecte, phrase par
+// phrase (coupée sur . ! ? ou saut de ligne), une répétition. looping=true dès
+// que la MÊME phrase normalisée atteint repetitionGuardThreshold occurrences ;
+// sentence porte alors cette phrase (pour l'expliquer au modèle ensuite).
+func (g *repetitionGuard) feed(chunk string) (looping bool, sentence string) {
+	if g.seen == nil {
+		g.seen = map[string]int{}
+	}
+	g.buf.WriteString(chunk)
+	for {
+		s := g.buf.String()
+		idx := strings.IndexAny(s, ".!?\n")
+		if idx < 0 {
+			break
+		}
+		raw := s[:idx+1]
+		g.buf.Reset()
+		g.buf.WriteString(s[idx+1:])
+		norm := strings.Join(strings.Fields(strings.ToLower(raw)), " ")
+		if len(norm) < repetitionGuardMinLen {
+			continue
+		}
+		g.seen[norm]++
+		if g.seen[norm] >= repetitionGuardThreshold {
+			return true, strings.TrimSpace(raw)
+		}
+	}
+	return false, ""
+}
+
+// truncateRunes coupe s à n runes (jamais en plein milieu d'un caractère
+// multi-octets), avec une ellipse si tronqué.
+func truncateRunes(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "…"
+}
+
 func runChat(ctx context.Context, messages []Message, temperature float64, caps Caps, cb ChatCallback) ([]Message, error) {
 	var extra []Message
 	tools := EnabledTools(caps)
@@ -757,14 +824,22 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 	// la réponse progressivement (voir repeatedCallResult) : rendre le contenu une
 	// fois, puis refuser en le renvoyant vers ce qu'il a déjà.
 	repeatCount := map[string]int{}
-	// Garde-fou « pensé sans agir » : certains modèles à reasoning planifient un
-	// appel d'outil dans leur <think> puis émettent le token de fin SANS l'émettre
-	// (ni réponse, ni tool_call). On relance alors le tour avec un nudge explicite
-	// au lieu d'afficher « pas de réponse ». Le premier nudge suffit la plupart du
-	// temps ; un second, plus direct, rattrape le cas observé où le modèle
-	// re-décrit le même plan en boucle sans jamais l'exécuter (une simple
-	// reformulation de « agis » ne suffit alors plus). Borné à maxNudges : un
-	// modèle vraiment bloqué doit finir par rendre la main, pas faire attendre.
+	// Garde-fou « le modèle est coincé » : deux signes distincts partagent le
+	// même compteur/plafond, ce sont deux symptômes du même problème. (1) pensé
+	// sans agir : certains modèles à reasoning planifient un appel d'outil dans
+	// leur <think> puis émettent le token de fin SANS l'émettre (ni réponse, ni
+	// tool_call) — parfois après avoir reformulé le même plan plusieurs fois sans
+	// jamais l'exécuter (observé : ~15 000 tokens de raisonnement en boucle sur
+	// une tâche complexe, zéro contenu visible). (2) répétition mécanique
+	// détectée EN COURS de flux par repetitionGuard (voir son commentaire et son
+	// utilisation plus bas) : deux blocages réels analysés montraient une phrase
+	// quasi identique revenant 82 puis 132 fois — (1) seul ne les aurait jamais
+	// interrompus puisque le modèle finit par émettre un finish_reason normal
+	// après avoir tout dit, juste beaucoup trop tard. Dans les deux cas on
+	// relance le tour avec un nudge explicite au lieu d'afficher tout de suite
+	// « pas de réponse » — maxNudges fois, pas plus : un modèle vraiment bloqué
+	// doit finir par rendre la main plutôt que de faire attendre indéfiniment
+	// (voir le message affiché après le dernier essai).
 	const maxNudges = 2
 	nudgeCount := 0
 	// Pas de plafond d'itérations ni d'anti-boucle : ils coupaient des tours
@@ -888,6 +963,11 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 		sawReasoningField := false
 		thinkOpen := reasoningOn
 		var thinkTail strings.Builder
+		// Anti-boucle : réinitialisé à CHAQUE complétion (voir repetitionGuard) —
+		// une répétition détectée ici coupe la lecture du flux plus bas.
+		var loopGuard repetitionGuard
+		loopDetected := false
+		loopSentence := ""
 		// Scanner à gros tampon : un chunk peut porter un gros JSON d'arguments
 		// (écriture de fichier). 8 Mio et non 1 : au-delà du tampon, le scanner
 		// s'arrête sur « token too long » AU MILIEU du flux, et jusqu'à la 0.8.4
@@ -1025,6 +1105,11 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 					aborted = true
 					break
 				}
+				if looping, sentence := loopGuard.feed(ch.Delta.ReasoningContent); looping {
+					loopDetected = true
+					loopSentence = sentence
+					break
+				}
 			}
 			if ch.Delta.Content != "" {
 				assistantContent.WriteString(ch.Delta.Content)
@@ -1105,6 +1190,25 @@ func runChat(ctx context.Context, messages []Message, temperature float64, caps 
 			err := streamCutError(scanErr)
 			cb(StreamEvent{Err: err})
 			return extra, err
+		}
+
+		// Le modèle rabâchait la même phrase (voir repetitionGuard) : on a coupé la
+		// lecture du flux tôt (dès la 3e répétition, pas après des dizaines) plutôt
+		// que d'attendre une fin de tour normale qui n'allait pas venir. Les appels
+		// d'outils accumulés jusque-là (s'il y en a) sont abandonnés avec le reste :
+		// une répétition en cours de <think> n'a rien produit d'exploitable.
+		if loopDetected {
+			if nudgeCount < maxNudges {
+				nudgeCount++
+				cb(StreamEvent{DropReasoning: true})
+				messages = append(messages, Message{
+					Role: "user",
+					Content: "You've repeated the same point several times in a row without making progress (\"" + truncateRunes(loopSentence, 180) + "\") — that's a sign this approach is stuck. Drop it: try something concretely different (a different method, tool, or angle), or if you already know enough, give your answer now. Don't repeat that reasoning again.",
+				})
+				continue
+			}
+			cb(StreamEvent{Content: "_(le modèle tournait en boucle sur la même idée — arrêté après " + strconv.Itoa(repetitionGuardThreshold) + " répétitions)_"})
+			return extra, nil
 		}
 
 		// Treat any accumulated tool calls as a tool turn even if the backend set

--- a/internal/ajean/llm_client_repetition_test.go
+++ b/internal/ajean/llm_client_repetition_test.go
@@ -1,0 +1,93 @@
+package ajean
+
+import "testing"
+
+func TestRepetitionGuardIgnoresDistinctSentences(t *testing.T) {
+	var g repetitionGuard
+	sentences := []string{
+		"I'm going to read the first ten bytes of the header to check the magic number.",
+		"That confirms it's a valid GGUF file, version three as expected.",
+		"Now let me look at the tensor count and the metadata key-value count.",
+		"The architecture key says qwen35, which matches what I saw earlier.",
+	}
+	for _, s := range sentences {
+		if looping, _ := g.feed(s + " "); looping {
+			t.Fatalf("distinct sentence wrongly flagged as a loop: %q", s)
+		}
+	}
+}
+
+func TestRepetitionGuardTriggersAtThreshold(t *testing.T) {
+	var g repetitionGuard
+	sentence := "I'm realizing the atlas layout is more complex than a simple grid, glyphs have varying heights and positions."
+	for i := 1; i < repetitionGuardThreshold; i++ {
+		if looping, _ := g.feed(sentence + " "); looping {
+			t.Fatalf("triggered too early, on repeat #%d (threshold is %d)", i, repetitionGuardThreshold)
+		}
+	}
+	looping, got := g.feed(sentence + " ")
+	if !looping {
+		t.Fatalf("expected loop detection on repeat #%d, got none", repetitionGuardThreshold)
+	}
+	if got == "" {
+		t.Fatal("expected the detected sentence to be returned, got empty string")
+	}
+}
+
+func TestRepetitionGuardIgnoresShortFiller(t *testing.T) {
+	var g repetitionGuard
+	// "Let me check." et "OK, next." reviennent légitimement dans un raisonnement
+	// normal sans jamais signaler un blocage — repetitionGuardMinLen doit les
+	// écarter même répétées bien plus de repetitionGuardThreshold fois.
+	for i := 0; i < 10; i++ {
+		if looping, _ := g.feed("Let me check. "); looping {
+			t.Fatalf("short filler sentence wrongly flagged as a loop on iteration %d", i)
+		}
+	}
+}
+
+func TestRepetitionGuardNormalizesWhitespaceAndCase(t *testing.T) {
+	var g repetitionGuard
+	variants := []string{
+		"This is a fairly long sentence about the font atlas layout that repeats.",
+		"THIS IS A FAIRLY LONG SENTENCE ABOUT THE FONT ATLAS LAYOUT THAT REPEATS.",
+		"This   is  a fairly long   sentence about the font atlas layout that repeats.",
+	}
+	for i, v := range variants {
+		looping, _ := g.feed(v + " ")
+		if i < repetitionGuardThreshold-1 && looping {
+			t.Fatalf("triggered too early on variant %d", i)
+		}
+		if i == repetitionGuardThreshold-1 && !looping {
+			t.Fatalf("case/whitespace variants weren't recognized as the same sentence")
+		}
+	}
+}
+
+// TestRepetitionGuardOnRealLoopTranscript rejoue (en abrégé) le motif observé
+// dans un vrai blocage capturé en production : la même phrase quasi identique
+// revenait des dizaines de fois dans le raisonnement d'un modèle coincé sur un
+// déchiffrage d'atlas de police. Vérifie que le détecteur aurait coupé net à
+// la 3e occurrence plutôt que de laisser filer jusqu'à la 82e comme ce jour-là.
+func TestRepetitionGuardOnRealLoopTranscript(t *testing.T) {
+	var g repetitionGuard
+	real := "I'm realizing the atlas might not follow a simple row-based structure—band1 has 16 glyphs while band0 has 8, which breaks the pattern I was assuming."
+	other := "This suggests the font atlas uses a bin-packing algorithm that groups glyphs by height rather than following a fixed grid."
+	// Le vrai transcript alternait deux phrases qui revenaient chacune ~80 fois ;
+	// on ne rejoue que les 5 premiers tours pour vérifier le déclenchement précoce.
+	turns := []string{real, other, real, other, real}
+	triggeredAt := -1
+	for i, s := range turns {
+		if looping, _ := g.feed(s + " "); looping {
+			triggeredAt = i
+			break
+		}
+	}
+	// real apparaît aux index 0, 2, 4 (1re, 2e, 3e occurrence) — le déclenchement
+	// attendu est donc à l'index 4, pas 2 : la garde compte par phrase normalisée,
+	// pas par position, donc "other" intercalé entre les occurrences ne la trompe
+	// pas (mais ne l'accélère pas non plus).
+	if triggeredAt != 4 {
+		t.Fatalf("expected the guard to trigger on the 3rd occurrence of `real` (index 4), got index %d", triggeredAt)
+	}
+}


### PR DESCRIPTION
## Summary

Extracted from the old #60 (closed) — that PR bundled this with two other changes you already took separately in v0.13.6. This is just the repetitionGuard piece on its own, rebased on current main.

Recap of what it does: watches the `reasoning_content` stream sentence-by-sentence and flags a loop the moment ANY normalized sentence repeats 3 times, aborts the in-flight request, and reuses the same nudge/retry path as the "reasoned but never answered" nudge you already merged.

## On your false-positive concern

You asked for measurements across several models before reconsidering — I want to be upfront that I don't have that. Everything here was tested against exactly one model (a Qwen3.5-family 27B build) on one machine. I don't have access to other model families to check whether this threshold trips on legitimate verbatim restatement patterns some of them use.

What I do have: the threshold (3 exact repeats, sentences under 40 chars exempted) was set by replaying the literal repeated text from two real incidents on that one model (82 and 132 repeats of the same sentence before it stopped on its own) — so I know it fires well before those specific incidents would have resolved either way, and I have unit tests asserting it doesn't fire on distinct sentences or short filler. That's evidence it's not hair-trigger on *this* model, not evidence it's safe across the exotic ones you mention running.

If you'd rather leave this out until there's broader evidence, that's a completely reasonable call and I won't push back on it — flagging the gap rather than asking you to take it on faith.

## Testing

- `go build ./...`, `go vet ./internal/ajean/...` clean.
- 5 unit tests: distinct sentences don't trigger, triggers exactly at the 3rd repeat (not before), short filler is exempt, whitespace/case normalization treats near-identical text as the same sentence, and a replay of the literal repeated sentence from a real incident's transcript.
- Deployed and running locally against real usage since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)