### PR TITLE
test: two more tests with the same real-llama-server dependency as the one already fixed

### DIFF
--- a/internal/ajean/chat_compact_test.go
+++ b/internal/ajean/chat_compact_test.go
@@ -107,6 +107,17 @@ func TestCompactBoundsSplitsLongToolLoop(t *testing.T) {
 // `user` restant était le tout premier de la conversation (épinglé en tête) et
 // le modèle répondait à celui-là au lieu de continuer la recherche.
 func TestCompactKeepsPendingRequest(t *testing.T) {
+	// Isolation + stub réseau : sans ça ce test tape le VRAI llama-server local
+	// (LLMPort en dur dans summarizeTranscript) et devient lent/instable dès
+	// qu'un modèle tourne en parallèle sur cette machine — même défaut déjà
+	// corrigé sur TestCompactArchivesBigBlock (chat_recall_test.go), repéré ici
+	// en creusant un blocage de plusieurs dizaines de secondes sur `go test`. La
+	// demande en cours survit à la compaction que le résumé aboutisse ou pas
+	// (voir compactMessages : `pending` est réinjecté après `mid` dans les deux
+	// cas), donc un résumé stubbé qui réussit ne change rien à ce que ce test
+	// vérifie.
+	testHome(t)
+	summarizerStub(t, "Résumé de test : recherche des horaires de train pour Lyon, plusieurs pages web lues.")
 	page := func(n int) Message {
 		return tm("contenu de page web très long " + string(rune('a'+n)) + strings.Repeat("x", 400))
 	}
@@ -117,8 +128,6 @@ func TestCompactKeepsPendingRequest(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		msgs = append(msgs, atc("web_read"), page(i))
 	}
-	// summarizeTranscript échoue (pas de llama-server en test) → torse dégraissé,
-	// ce qui n'enlève rien à ce qu'on vérifie ici : la demande doit survivre.
 	out, _ := compactMessages(t.Context(), msgs, Caps{})
 	found := false
 	for _, m := range out {

--- a/internal/ajean/chat_recall_test.go
+++ b/internal/ajean/chat_recall_test.go
@@ -147,7 +147,12 @@ func TestCompactArchivesBigBlock(t *testing.T) {
 // Sans mode agent, on n'archive pas (le modèle n'a pas l'outil recall) : aucun
 // bloc ne doit être créé, le résumé reste propre.
 func TestCompactNoArchiveWithoutAgent(t *testing.T) {
-	t.Setenv("AJEAN_HOME", t.TempDir())
+	testHome(t)
+	// Même défaut que TestCompactArchivesBigBlock plus haut dans ce fichier
+	// (déjà stubbé) : sans ça ce test tape aussi le vrai llama-server local.
+	// Repéré en creusant un blocage réseau sur `go test` alors que ce fichier
+	// avait déjà le correctif juste au-dessus.
+	summarizerStub(t, "Résumé de test : rien de particulier à retenir.")
 	big := strings.Repeat("contenu volumineux ", 100)
 	msgs := []Message{um("q"), atc("web_read"), tm(big)}
 	for i := 0; i < 8; i++ {


### PR DESCRIPTION
## Summary

Same class of bug you already took the fix for (`TestCompactArchivesBigBlock`, v0.13.6): `TestCompactKeepsPendingRequest` and `TestCompactNoArchiveWithoutAgent`, in the same two test files, both call `compactMessages` without stubbing `summarizeTranscript`'s network call — so they hit the real `LLMPort()` on whatever machine runs them.

Found by accident while building an unrelated branch: `go test` hung for 30-90s instead of finishing in under a second. A stack dump pointed straight at `summarizeTranscript` blocked on a live HTTP read from `chat_compact_test.go:122` / `chat_recall_test.go:156`.

Same fix, reusing the `summarizerStub` helper that's already in `chat_recall_test.go` from the earlier fix — no new code, just two more call sites wired to it.

## Testing

- `go build ./...` clean.
- Confirmed both tests actually depend on this: reverted the fix and re-ran just these two — they hang/fail against the real server on this machine, then pass instantly (both under 0.1s) with the stub restored.
- Full suite: 25s (was 60-90s+), only the pre-existing unrelated `TestSystemPromptStaysLean` failure remains (machine-local MMPROJ config, not a real regression — happy to give more detail if useful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)