### PR TITLE
chat: tag each turn with the preset that answered it

### DIFF
--- a/internal/ajean/backend_presets.go
+++ b/internal/ajean/backend_presets.go
@@ -86,6 +86,23 @@ func isPreservedKey(key string) bool {
 
 // ListPresets renvoie tous les presets/*.env, en marquant celui qui correspond
 // à la configuration active (clés « appareil » ignorées), triés par nom.
+// activePresetName renvoie le nom d'affichage du preset actif, ou "" si
+// indéterminable (aucun preset, erreur de lecture...) — jamais une erreur qui
+// remonterait à l'appelant, juste une info de confort journalisée par tour
+// (voir StartTurn dans chat_conversation.go).
+func activePresetName() string {
+	list, err := ListPresets()
+	if err != nil {
+		return ""
+	}
+	for _, p := range list {
+		if p.Active {
+			return p.Name
+		}
+	}
+	return ""
+}
+
 func ListPresets() ([]Preset, error) {
 	dir := presetsDir()
 	_ = os.MkdirAll(dir, 0o755)

--- a/internal/ajean/chat_conversation.go
+++ b/internal/ajean/chat_conversation.go
@@ -479,7 +479,16 @@ func (c *Conversation) StartTurn(text string, files []attachInfo, caps Caps, tem
 	// Borne de tour + bulle utilisateur (rejouables). Persistée tout de suite :
 	// si le process meurt en pleine génération (crash, restart après MAJ), le
 	// message de l'utilisateur survit au lieu de disparaître avec le tour.
+	// `model` journalise le preset actif AU MOMENT de l'envoi (issue #45 upstream) :
+	// changer de preset en cours de conversation ne dit auparavant nulle part QUI
+	// a répondu à quoi — le libellé sous le composeur se contentait d'écraser le
+	// précédent, et l'historique perdait l'info à la relecture. Posé une fois par
+	// tour, comme `user` : pas un champ par delta de réponse (le modèle ne change
+	// pas EN COURS d'un même tour).
 	delta := map[string]any{"user": text}
+	if name := activePresetName(); name != "" {
+		delta["model"] = name
+	}
 	if len(files) > 0 {
 		delta["files"] = files
 	}

--- a/internal/ajean/ui/index.html
+++ b/internal/ajean/ui/index.html
@@ -6149,7 +6149,7 @@ function confirmPending(text){
 let REPLAYING=true;
 // État de rendu du tour courant, délimité par les événements user / turn_done.
 let T=null;
-function newTurn(){ T={ reasonEl:null, contentEl:null, pendingToolEl:null, activeEl:null, typingEl:null, fullContent:'', fullReason:'', turnCollapsibles:[], serverStats:null, reasonTok:0, contentTok:0, toolTok:0, reasonFirstTs:0, reasonLastTs:0, contentFirstTs:0, contentLastTs:0 }; }
+function newTurn(){ T={ reasonEl:null, contentEl:null, pendingToolEl:null, activeEl:null, typingEl:null, fullContent:'', fullReason:'', turnCollapsibles:[], serverStats:null, reasonTok:0, contentTok:0, toolTok:0, reasonFirstTs:0, reasonLastTs:0, contentFirstTs:0, contentLastTs:0, model:null }; }
 // « Élément actif » = la bulle qui porte le shimmer. Le voile reste dessus tant
 // qu'une nouvelle étape (raisonnement / outil / réponse) n'a pas pris le relais —
 // y compris pendant que l'IA LIT la réponse d'un outil terminé. On ne coupe donc
@@ -6292,6 +6292,9 @@ function finalizeTurn(elapsedMs){
   if(ELAPSED){ clearInterval(ELAPSED.timer); ELAPSED=null; }
   genStatusOn(false);
   const parts=[];
+  // En premier, façon "qui a répondu" — utile surtout si tu as changé de preset
+  // depuis le tour précédent ; sinon c'est juste un rappel discret et cohérent.
+  if(T.model) parts.push(T.model);
   if(elapsedMs>0) parts.push(fmtElapsed(elapsedMs/1000));
   if(tok>0){ parts.push(fmtTok(tok)+' tok'); if(rate!=null) parts.push(rate.toFixed(1)+' tok/s'); }
   if(!parts.length){ removeGenEl(); scrollMaybe(true); return; }
@@ -6526,6 +6529,11 @@ function handleDelta(d){
     TURN_ENDED=true; elapsedStop(); smoothReset(); if(renderTimer){ clearTimeout(renderTimer); renderTimer=null; } renderPending=null; PENDING=null; document.getElementById('chat').innerHTML=''; newTurn(); setCtxUsed(0); setCompactCount(0); lastSeq=0; setBusy(false); return; }
   if(d.user!==undefined){
     newTurn();
+    // Preset actif AU MOMENT de l'envoi (issue #45 upstream : savoir quel modèle a
+    // répondu à quoi après un changement en cours de conversation). Posé une fois
+    // par tour sur le MÊME delta que `user`, donc rejoué à l'identique — pas de
+    // traitement replay séparé à écrire.
+    if(d.model) T.model=d.model;
     let el=PENDING;
     if(!confirmPending(d.user)) el=addMsg('user', d.user);
     // Pièces jointes du tour : rendues DANS la bulle. La bulle en attente en

--- a/internal/ajean/ui/src/js/09-stream.js
+++ b/internal/ajean/ui/src/js/09-stream.js
@@ -44,7 +44,7 @@ function confirmPending(text){
 let REPLAYING=true;
 // État de rendu du tour courant, délimité par les événements user / turn_done.
 let T=null;
-function newTurn(){ T={ reasonEl:null, contentEl:null, pendingToolEl:null, activeEl:null, typingEl:null, fullContent:'', fullReason:'', turnCollapsibles:[], serverStats:null, reasonTok:0, contentTok:0, toolTok:0, reasonFirstTs:0, reasonLastTs:0, contentFirstTs:0, contentLastTs:0 }; }
+function newTurn(){ T={ reasonEl:null, contentEl:null, pendingToolEl:null, activeEl:null, typingEl:null, fullContent:'', fullReason:'', turnCollapsibles:[], serverStats:null, reasonTok:0, contentTok:0, toolTok:0, reasonFirstTs:0, reasonLastTs:0, contentFirstTs:0, contentLastTs:0, model:null }; }
 // « Élément actif » = la bulle qui porte le shimmer. Le voile reste dessus tant
 // qu'une nouvelle étape (raisonnement / outil / réponse) n'a pas pris le relais —
 // y compris pendant que l'IA LIT la réponse d'un outil terminé. On ne coupe donc
@@ -187,6 +187,9 @@ function finalizeTurn(elapsedMs){
   if(ELAPSED){ clearInterval(ELAPSED.timer); ELAPSED=null; }
   genStatusOn(false);
   const parts=[];
+  // En premier, façon "qui a répondu" — utile surtout si tu as changé de preset
+  // depuis le tour précédent ; sinon c'est juste un rappel discret et cohérent.
+  if(T.model) parts.push(T.model);
   if(elapsedMs>0) parts.push(fmtElapsed(elapsedMs/1000));
   if(tok>0){ parts.push(fmtTok(tok)+' tok'); if(rate!=null) parts.push(rate.toFixed(1)+' tok/s'); }
   if(!parts.length){ removeGenEl(); scrollMaybe(true); return; }
@@ -421,6 +424,11 @@ function handleDelta(d){
     TURN_ENDED=true; elapsedStop(); smoothReset(); if(renderTimer){ clearTimeout(renderTimer); renderTimer=null; } renderPending=null; PENDING=null; document.getElementById('chat').innerHTML=''; newTurn(); setCtxUsed(0); setCompactCount(0); lastSeq=0; setBusy(false); return; }
   if(d.user!==undefined){
     newTurn();
+    // Preset actif AU MOMENT de l'envoi (issue #45 upstream : savoir quel modèle a
+    // répondu à quoi après un changement en cours de conversation). Posé une fois
+    // par tour sur le MÊME delta que `user`, donc rejoué à l'identique — pas de
+    // traitement replay séparé à écrire.
+    if(d.model) T.model=d.model;
     let el=PENDING;
     if(!confirmPending(d.user)) el=addMsg('user', d.user);
     // Pièces jointes du tour : rendues DANS la bulle. La bulle en attente en


### PR DESCRIPTION
## Summary

Split out of the old #59 which bundled 5 unrelated features into one PR — this is just the per-turn model tag (originally issue #45). No dependency on the i18n PR — the model name itself is dynamic (user-chosen preset text), so there's no new static string to translate.

With several presets/models in rotation, there was no record of which one actually produced a given reply once you'd switched presets since. \`activePresetName()\` reads the currently-active preset at the moment a turn starts and tags it onto the turn (\`chat_conversation.go\`); the UI shows it as the first element of the per-message stats line (model · elapsed · tokens · rate), and it's carried through export/history like the rest of a turn's metadata.

## Testing

- \`go build ./...\`, \`go vet ./internal/ajean/...\` clean.
- Confirmed in browser: switching presets between turns correctly tags each turn with the preset active at the time.
- Full suite green (aside from the pre-existing, unrelated \`TestSystemPromptStaysLean\` — machine-local MMPROJ config, not a real regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)