### PR TITLE
Passation : point de sauvegarde volontaire de la conversation

### DIFF
--- a/internal/ajean/chat_passation.go
+++ b/internal/ajean/chat_passation.go
@@ -1,0 +1,231 @@
+package ajean
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// chat_passation.go — La PASSATION : un point de sauvegarde volontaire de la
+// conversation, écrit comme page mémoire datée. L'utilisateur la déclenche
+// quand il le veut (bouton « passation » dans le menu +) ; elle ne supprime
+// rien, n'injecte rien, ne vide pas la session. C'est un document stable que
+// l'IA peut relire dans une session future pour reprendre là où on s'était
+// arrêté, sans porter le « poison » d'un contexte compacté.
+//
+// Structure imposée au modèle :
+//   Objectif
+//   Problématique
+//   Fichiers importants
+//   Ce qui a raté
+//   Prochaine étape
+//
+// Le nom de la page est passation-YYYY-MM-DD-HHMM.md (jamais d'écrasement).
+// Si le nom est déjà pris (deux passations à la même minute), on ajoute -2, -3…
+
+const passationPrompt = `Tu es un rédacteur de passation. Tu lis la transcription d'une conversation entre un humain et un IA (avec ses outils). Tu en extrais un document structuré, destiné à être relu dans une session neuve pour reprendre exactement là où on s'est arrêté.
+
+Structure EXACTE (pas d'autre section, pas de préambule) :
+## Objectif
+Ce que la conversation cherchait à accomplir. En 1-2 phrases.
+
+## Problématique
+Les contraintes, les difficultés, les points d'attention qui restent. En quelques puces.
+
+## Fichiers importants
+Chemin (ou nom) + un mot sur le rôle de chaque fichier pertinent. Liste courte.
+
+## Ce qui a raté
+Ce qui a échoué, été abandonné, ou reste inconnu. Si rien : « — ».
+
+## Prochaine étape
+L'action concrète immédiate à faire pour continuer. 1-3 puces.
+
+Règles :
+- Pas de verbatim, pas de longue citation.
+- Pas de méta-commentaire (« Cette passation… »).
+- Dense, factuel, actionnable.
+- En même langue que la conversation.
+- Pas de limite de longueur : sois COMPLET plutôt que court. Chaque section doit porter tout ce qui est utile à la reprise ; développe autant que nécessaire.`
+
+// passationName génère le nom de page mémoire : passation-YYYY-MM-DD-HHMM.md
+// Si le nom existe déjà (passation précédente à la même minute), on ajoute -2, -3…
+// jusqu'à trouver un nom libre. Jamais d'écrasement.
+func passationName() string {
+	stamp := time.Now().Format("2006-01-02-1504")
+	base := "passation-" + stamp + ".md"
+	if !memNameTaken(base) {
+		return base
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("passation-%s-%d.md", stamp, i)
+		if !memNameTaken(candidate) {
+			return candidate
+		}
+	}
+}
+
+// memNameTaken dit si une page mémoire porte déjà ce nom.
+func memNameTaken(name string) bool {
+	p, err := safeMemPath(name)
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(p)
+	return err == nil
+}
+
+// passationTranscript rend la transcription de la conversation pour le résumeur.
+// On plafonne à ~0.7× la fenêtre (en caractères) en gardant la FIN (la plus
+// récente), comme renderTranscript.
+func passationTranscript(msgs []Message) string {
+	var b strings.Builder
+	for _, m := range msgs {
+		switch m.Role {
+		case "user":
+			fmt.Fprintf(&b, "User: %s\n", msgText(m))
+		case "assistant":
+			if t := msgText(m); t != "" {
+				fmt.Fprintf(&b, "Assistant: %s\n", t)
+			}
+			for _, tc := range m.ToolCalls {
+				fmt.Fprintf(&b, "Assistant → tool %s(%s)\n", tc.Function.Name, tc.Function.Arguments)
+			}
+		case "tool":
+			// Raccourcir les résultats d'outils longs (comme le compacteur).
+			if t := msgText(m); len(t) > 800 {
+				fmt.Fprintf(&b, "Tool result: %s\n[…suite coupée]\n", t[:800])
+			} else {
+				fmt.Fprintf(&b, "Tool result: %s\n", t)
+			}
+		case "system":
+			// On inclut le system pour que le modèle sache quel projet on est sur.
+			fmt.Fprintf(&b, "System: %s\n", msgText(m))
+		}
+	}
+	s := b.String()
+	maxChars := int(float64(ctxWindow()) * 2.8)
+	if maxChars > 0 && len(s) > maxChars {
+		s = "[…début tronqué…]\n" + s[len(s)-maxChars:]
+	}
+	return s
+}
+
+// runPassation lance l'appel au modèle et écrit la page mémoire. Renvoie le nom
+// de la page créée. Les événements de progression sont publiés dans le flux.
+func (c *Conversation) runPassation(ctx context.Context, epoch int) (string, error) {
+	// Vérifier qu'il y a au moins un message utilisateur.
+	hasUser := false
+	for _, m := range c.Messages {
+		if m.Role == "user" && strings.TrimSpace(msgText(m)) != "" {
+			hasUser = true
+			break
+		}
+	}
+	if !hasUser {
+		return "", fmt.Errorf("conversation vide — rien à passer")
+	}
+
+	c.appendDelta(epoch, map[string]any{"passation": "en_cours"})
+
+	transcript := passationTranscript(c.Messages)
+
+	// Appel au modèle (non streamé, comme summarizeTranscript).
+	payload := map[string]any{
+		"model": "ajean",
+		"messages": []Message{
+			{Role: "system", Content: passationPrompt},
+			{Role: "user",     Content: transcript},
+		},
+		"stream":      false,
+		"temperature": 0.3,
+		"max_tokens":  2048,
+		"chat_template_kwargs": map[string]any{"enable_thinking": false},
+	}
+	body, _ := json.Marshal(payload)
+	url := fmt.Sprintf("http://localhost:%d/v1/chat/completions", LLMPort())
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": err.Error()})
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	authHeader(req)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": err.Error()})
+		return "", friendlyLLMError(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 500))
+		errMsg := fmt.Sprintf("modèle %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": errMsg})
+		return "", fmt.Errorf("%s", errMsg)
+	}
+
+	var out struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": "réponse illisible"})
+		return "", fmt.Errorf("réponse du modèle illisible: %w", err)
+	}
+	if len(out.Choices) == 0 || strings.TrimSpace(out.Choices[0].Message.Content) == "" {
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": "réponse vide du modèle"})
+		return "", fmt.Errorf("le modèle n'a produit aucun contenu")
+	}
+
+	content := strings.TrimSpace(out.Choices[0].Message.Content)
+
+	// Écrire la page mémoire (MemAdd gère le chiffrement + l'index MEMORY.md).
+	name := passationName()
+	if err := MemAdd(name, content); err != nil {
+		c.appendDelta(epoch, map[string]any{"passation": "erreur", "detail": err.Error()})
+		return "", fmt.Errorf("écriture mémoire: %w", err)
+	}
+
+	c.appendDelta(epoch, map[string]any{"passation": "done", "file": name})
+	return name, nil
+}
+
+// PassationNow est appelé par le handler HTTP. Lance la passation en
+// arrière-plan (comme CompactNow) et renvoie immédiatement.
+func (c *Conversation) PassationNow() error {
+	if !healthCheck() {
+		return errModelLoading
+	}
+	c.mu.Lock()
+	if c.Generating {
+		c.mu.Unlock()
+		return ErrBusy
+	}
+	c.Generating = true
+	epoch := c.epoch
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+	c.mu.Unlock()
+
+	go func() {
+		defer func() {
+			c.mu.Lock()
+			if c.epoch == epoch {
+				c.Generating = false
+				c.cancel = nil
+			}
+			c.mu.Unlock()
+		}()
+		c.runPassation(ctx, epoch)
+	}()
+	return nil
+}

--- a/internal/ajean/chat_passation_test.go
+++ b/internal/ajean/chat_passation_test.go
@@ -1,0 +1,12 @@
+package ajean
+import "testing"
+func TestPassationNameUnique(t *testing.T){
+  a := passationName()
+  // créer la page puis demander à nouveau → doit être différent
+  if err := MemAdd(a, "## Objectif\nx\n"); err != nil { t.Fatalf("MemAdd: %v", err) }
+  b := passationName()
+  if a == b { t.Fatalf("attendu un nom différent, obtenu %s deux fois", a) }
+  t.Logf("première=%s suivante=%s", a, b)
+  // cleanup
+  _ = MemDelete(a)
+}

--- a/internal/ajean/ui/index.html
+++ b/internal/ajean/ui/index.html
@@ -5979,6 +5979,20 @@ async function compactContext(){
     if(!j.ok) toast(j.error||'compaction indisponible');
   }catch(e){ toast('erreur : '+(e.message||e)); }
 }
+// Passation : l'IA résume la conversation dans la trame imposée (Objectif /
+// Problématique / Fichiers importants / Ce qui a raté / Prochaine étape) et
+// pose le document comme PAGE MÉMOIRE datée (passation-<date>.md, jamais
+// écrasée). Ne vide rien, n'injecte rien — la conversation continue. La
+// reprise se fera plus tard par une demande explicite (« lis la passation la
+// plus récente et reprends »). La progression arrive par le flux (passation).
+async function makePassation(){
+  if(!await askConfirm('Résumer la conversation en passation (Objectif / Problématique / Fichiers importants / Ce qui a raté / Prochaine étape) et la poser comme page mémoire datée ? Rien n\u2019est vidé : tu pourras repartir dessus quand tu veux.', {title:'Passation', okText:'Écrire la passation'})) return;
+  try{
+    const r=await jfetch('/api/chat/passation',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    const j=await r.json().catch(()=>({}));
+    if(!j.ok) toast(j.error||'passation indisponible');
+  }catch(e){ toast('erreur : '+(e.message||e)); }
+}
 // Persistance de la conversation : on garde user+assistant en localStorage pour
 // survivre à un refresh (les bulles tool/reasoning sont éphémères, non stockées).
 function saveChat(){ try{ localStorage.setItem('ajean.chat', JSON.stringify(msgs)); }catch(e){} }
@@ -6543,6 +6557,15 @@ function handleDelta(d){
   if(d.error){ smoothSnap(); flushRender(); elapsedStop(); removeTyping(); setActive(null); T.contentEl=null; T.reasonEl=null; const eb=addMsg('assistant',''); eb.classList.add('errmsg'); renderBody(eb, d.error); return; }
   if(d.compacting!==undefined){ setCompacting(d.compacting); return; }
   if(d.compacted){ setCompacting(false); addCompactMark(); return; }
+  // Passation : point de sauvegarde volontaire → page mémoire datée. La
+  // progression est un événement ponctuel (toast en direct, silencieux au
+  // replay, comme compact_noop) — la trace durable, c'est la page mémoire elle-même.
+  if(d.passation){
+    if(d.passation==='done'){ if(!REPLAYING) toast('passation écrite : '+d.file); }
+    else if(d.passation==='erreur'){ if(!REPLAYING) toast('passation : '+(d.detail||'erreur')); }
+    // 'en_cours' : silencieux (l'appel au modèle peut durer).
+    return;
+  }
   // Pas de toast au REPLAY : le journal est rejoué à chaque chargement de page,
   // donc une notification persistée se re-déclenchait à chaque rafraîchissement
   // (« rien à compacter » qui revient sans raison). C'est un événement ponctuel,
@@ -8769,6 +8792,12 @@ function togglePlusMenu(e){
   if(typeof COMPACT_AVAILABLE!=='undefined' && COMPACT_AVAILABLE){
     pop.appendChild(item(icCompact, 'Compacter le contexte', ()=>{ if(typeof compactContext==='function') compactContext(); }));
   }
+  // « Passation » : l'IA résume la conversation (Objectif / Problématique /
+  // Fichiers importants / Ce qui a raté / Prochaine étape) et pose le document
+  // comme page mémoire datée. Ne vide rien, n'injecte rien — la reprise est une
+  // demande explicite de l'utilisateur dans la session d'après.
+  const icPassation = '<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>';
+  pop.appendChild(item(icPassation, 'Passation (reprendre plus tard)', ()=>{ if(typeof makePassation==='function') makePassation(); }));
   document.body.appendChild(pop);
   // Positionne AU-DESSUS du bouton (le composeur est en bas de l'écran), calé à gauche.
   // Écart plus généreux pour ne pas coller à la zone de saisie.

--- a/internal/ajean/ui/src/js/08-chat-render.js
+++ b/internal/ajean/ui/src/js/08-chat-render.js
@@ -522,6 +522,20 @@ async function compactContext(){
     if(!j.ok) toast(j.error||'compaction indisponible');
   }catch(e){ toast('erreur : '+(e.message||e)); }
 }
+// Passation : l'IA résume la conversation dans la trame imposée (Objectif /
+// Problématique / Fichiers importants / Ce qui a raté / Prochaine étape) et
+// pose le document comme PAGE MÉMOIRE datée (passation-<date>.md, jamais
+// écrasée). Ne vide rien, n'injecte rien — la conversation continue. La
+// reprise se fera plus tard par une demande explicite (« lis la passation la
+// plus récente et reprends »). La progression arrive par le flux (passation).
+async function makePassation(){
+  if(!await askConfirm('Résumer la conversation en passation (Objectif / Problématique / Fichiers importants / Ce qui a raté / Prochaine étape) et la poser comme page mémoire datée ? Rien n\u2019est vidé : tu pourras repartir dessus quand tu veux.', {title:'Passation', okText:'Écrire la passation'})) return;
+  try{
+    const r=await jfetch('/api/chat/passation',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    const j=await r.json().catch(()=>({}));
+    if(!j.ok) toast(j.error||'passation indisponible');
+  }catch(e){ toast('erreur : '+(e.message||e)); }
+}
 // Persistance de la conversation : on garde user+assistant en localStorage pour
 // survivre à un refresh (les bulles tool/reasoning sont éphémères, non stockées).
 function saveChat(){ try{ localStorage.setItem('ajean.chat', JSON.stringify(msgs)); }catch(e){} }

--- a/internal/ajean/ui/src/js/09-stream.js
+++ b/internal/ajean/ui/src/js/09-stream.js
@@ -438,6 +438,15 @@ function handleDelta(d){
   if(d.error){ smoothSnap(); flushRender(); elapsedStop(); removeTyping(); setActive(null); T.contentEl=null; T.reasonEl=null; const eb=addMsg('assistant',''); eb.classList.add('errmsg'); renderBody(eb, d.error); return; }
   if(d.compacting!==undefined){ setCompacting(d.compacting); return; }
   if(d.compacted){ setCompacting(false); addCompactMark(); return; }
+  // Passation : point de sauvegarde volontaire → page mémoire datée. La
+  // progression est un événement ponctuel (toast en direct, silencieux au
+  // replay, comme compact_noop) — la trace durable, c'est la page mémoire elle-même.
+  if(d.passation){
+    if(d.passation==='done'){ if(!REPLAYING) toast('passation écrite : '+d.file); }
+    else if(d.passation==='erreur'){ if(!REPLAYING) toast('passation : '+(d.detail||'erreur')); }
+    // 'en_cours' : silencieux (l'appel au modèle peut durer).
+    return;
+  }
   // Pas de toast au REPLAY : le journal est rejoué à chaque chargement de page,
   // donc une notification persistée se re-déclenchait à chaque rafraîchissement
   // (« rien à compacter » qui revient sans raison). C'est un événement ponctuel,

--- a/internal/ajean/ui/src/js/18-projects.js
+++ b/internal/ajean/ui/src/js/18-projects.js
@@ -342,6 +342,12 @@ function togglePlusMenu(e){
   if(typeof COMPACT_AVAILABLE!=='undefined' && COMPACT_AVAILABLE){
     pop.appendChild(item(icCompact, 'Compacter le contexte', ()=>{ if(typeof compactContext==='function') compactContext(); }));
   }
+  // « Passation » : l'IA résume la conversation (Objectif / Problématique /
+  // Fichiers importants / Ce qui a raté / Prochaine étape) et pose le document
+  // comme page mémoire datée. Ne vide rien, n'injecte rien — la reprise est une
+  // demande explicite de l'utilisateur dans la session d'après.
+  const icPassation = '<svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M7 10l5 5 5-5M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/></svg>';
+  pop.appendChild(item(icPassation, 'Passation (reprendre plus tard)', ()=>{ if(typeof makePassation==='function') makePassation(); }));
   document.body.appendChild(pop);
   // Positionne AU-DESSUS du bouton (le composeur est en bas de l'écran), calé à gauche.
   // Écart plus généreux pour ne pas coller à la zone de saisie.

--- a/internal/ajean/web_chat.go
+++ b/internal/ajean/web_chat.go
@@ -228,6 +228,25 @@ func handleChatCompact(w http.ResponseWriter, r *http.Request) {
 	sendJSON(w, 200, map[string]any{"ok": true})
 }
 
+// handleChatPassation écrit une passation : le modèle résume la conversation
+// dans la trame imposée (Objectif / Problématique / Fichiers importants /
+// Ce qui a raté / Prochaine étape) et le résultat est posé comme page mémoire
+// datée (passation-YYYY-MM-DD-HHMM.md, jamais écrasée). Rien n'est vidé ni
+// injecté : la conversation continue, la reprise est une décision explicite
+// de l'utilisateur. La progression arrive par le flux (passation: en_cours /
+// done / erreur).
+func handleChatPassation(w http.ResponseWriter, r *http.Request) {
+	if err := conv.PassationNow(); err != nil {
+		code := 503
+		if err == ErrBusy {
+			code = 409
+		}
+		sendJSON(w, code, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	sendJSON(w, 200, map[string]any{"ok": true})
+}
+
 func handleChatState(w http.ResponseWriter, r *http.Request) {
 	sendJSON(w, 200, conv.state())
 }

--- a/internal/ajean/web_server.go
+++ b/internal/ajean/web_server.go
@@ -270,6 +270,7 @@ func newWebMux() *http.ServeMux {
 	api("/api/chat/history/fav", handleChatHistoryFav)         // épingle/dépingle en favori
 	api("/api/chat/history/clear", handleChatHistoryClear)     // supprime tout sauf les favoris
 	api("/api/chat/compact", handleChatCompact)                // compaction manuelle du contexte
+	api("/api/chat/passation", handleChatPassation)            // passation : résumé structuré → page mémoire datée (jamais écrasée)
 	api("/api/chat/state", handleChatState)                    // instantané léger {seq, generating, ctx_used}
 	api("/api/chat/export", handleChatExport)                  // téléchargement du fil (?format=md|json)
 	// /api/e2e/chat s'authentifie LUI-MÊME (e2eAuthOpenReq) : pas de requireWebAuth


### PR DESCRIPTION
Problème : la compaction automatique peut laisser dans le contexte des résidus (choix erronés, hypothèses fausses) qui empoisonnent les sessions suivantes.

Solution : un bouton « Passation » (menu +) qui demande au modèle un résumé structuré dans une trame imposée — Objectif / Problématique / Fichiers importants / Ce qui a raté / Prochaine étape — et le pose comme page mémoire datée passation-YYYY-MM-DD-HHMM.md (jamais écrasée, suffixe -2, -3… en cas de collision).

Garanties : ne vide pas la session, n'injecte rien dans le contexte, ne s'exécute jamais sans l'utilisateur. La reprise est une demande explicite ultérieure (« lis la passation la plus récente et reprends ») — l'IA y accède via l'index mémoire.

Surface : endpoint POST /api/chat/passation, progression diffusée par le flux (passation: en_cours|done|erreur, silencieux au replay), bouton dans le menu +, tests unitaires.